### PR TITLE
Ensure log file writes

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,8 +41,18 @@ METASHAPE_SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
 os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
 
-# Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+# Setup logging to both console and a log file. The log file is cleared on each
+# start to keep logs relevant to the current run.
+LOG_FILE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "app.log")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE_PATH, mode="w", encoding="utf-8"),
+        logging.StreamHandler(sys.stdout),
+    ],
+    force=True,  # apply configuration even if logging was already configured
+)
 
 
 # Helper function to check allowed files


### PR DESCRIPTION
## Summary
- set `force=True` on logging setup so file handler is always active

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686921f8c1a4833288051f22e6e34014