### PR TITLE
Add batch size override support

### DIFF
--- a/image_classifier_cpu.py
+++ b/image_classifier_cpu.py
@@ -23,10 +23,24 @@ feature_extractor = None
 device_name = None
 gpu_available = False
 batch_size = 8  # Will be auto-adjusted based on GPU memory
+# Allow overriding batch size via environment variable
+_env_batch = os.environ.get("BATCH_SIZE")
+if _env_batch:
+    try:
+        batch_size = int(_env_batch)
+        logging.info(f"🔧 Using batch size from environment: {batch_size}")
+    except ValueError:
+        logging.warning(
+            f"Invalid BATCH_SIZE value '{_env_batch}', falling back to auto detection"
+        )
 
 def detect_optimal_batch_size():
     """Detect optimal batch size based on GPU memory"""
     global batch_size
+
+    # Respect manual override if provided
+    if _env_batch:
+        return batch_size
     
     if not gpu_available:
         batch_size = 1

--- a/image_classifier_gpu.py
+++ b/image_classifier_gpu.py
@@ -20,9 +20,24 @@ feature_extractor = None
 device_name = None
 gpu_available = False
 batch_size = 8
+# Allow overriding batch size via environment variable
+_env_batch = os.environ.get("BATCH_SIZE")
+if _env_batch:
+    try:
+        batch_size = int(_env_batch)
+        logging.info(f"🔧 Using batch size from environment: {batch_size}")
+    except ValueError:
+        logging.warning(
+            f"Invalid BATCH_SIZE value '{_env_batch}', falling back to auto detection"
+        )
 
 def detect_optimal_batch_size():
     global batch_size
+
+    # Respect manual override if provided
+    if _env_batch:
+        return batch_size
+
     if not gpu_available:
         batch_size = 1
         return batch_size


### PR DESCRIPTION
## Summary
- enable custom batch size via `BATCH_SIZE` env var in image classifiers

## Testing
- `python -m py_compile image_classifier_cpu.py image_classifier_gpu.py`

------
https://chatgpt.com/codex/tasks/task_e_6869297c454c83328421d7c656075441