### PR TITLE
Add process tracking and listing

### DIFF
--- a/templates/file_selection.html
+++ b/templates/file_selection.html
@@ -123,8 +123,8 @@
             <input type="radio" name="file_type" value="zip"> فایل ZIP حاوی تصاویر  
         </label>  
         <button type="submit" class="btn">ادامه</button>  
-    </form>  
-
-    <a href="{{ url_for('logout') }}" class="logout-link">خروج</a> <!-- Logout link -->  
-</body>  
+    </form>
+    <a href="{{ url_for('process_list') }}" class="logout-link">مشاهده پردازش‌ها</a>
+    <a href="{{ url_for('logout') }}" class="logout-link">خروج</a> <!-- Logout link -->
+</body>
 </html>

--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="fa">
+<head>
+    <meta charset="UTF-8">
+    <title>لیست پردازش‌ها</title>
+    <style>
+        table {width: 100%; border-collapse: collapse;}
+        th, td {border: 1px solid #ccc; padding: 8px; text-align: center;}
+        th {background-color: #f0f0f0;}
+        .pagination {margin-top: 20px; text-align: center;}
+        .pagination a {margin: 0 5px; text-decoration: none;}
+    </style>
+</head>
+<body>
+    <h1>لیست پردازش‌ها</h1>
+    <table>
+        <tr>
+            <th>نام فایل</th>
+            <th>کاربر</th>
+            <th>تعداد فریم/تصویر</th>
+            <th>زمان شروع</th>
+            <th>زمان پایان</th>
+            <th>مدت‌زمان (ثانیه)</th>
+            <th>وضعیت</th>
+        </tr>
+        {% for p in processes %}
+        <tr>
+            <td>{{ p.filename }}</td>
+            <td>{{ p.user }}</td>
+            <td>{{ p.frame_count }}</td>
+            <td>{{ p.start_time }}</td>
+            <td>{{ p.end_time or '-' }}</td>
+            <td>{% if p.duration %}{{ '%.1f'|format(p.duration) }}{% else %}-{% endif %}</td>
+            <td>{{ p.status }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% if pagination.pages > 1 %}
+    <div class="pagination">
+        {% if pagination.has_prev %}
+            <a href="{{ url_for('process_list', page=pagination.prev_num) }}">&laquo; قبلی</a>
+        {% endif %}
+        صفحه {{ pagination.page }} از {{ pagination.pages }}
+        {% if pagination.has_next %}
+            <a href="{{ url_for('process_list', page=pagination.next_num) }}">بعدی &raquo;</a>
+        {% endif %}
+    </div>
+    {% endif %}
+    <a href="{{ url_for('file_selection') }}">بازگشت</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track processing jobs in a new `Process` model
- create `/processes` route with pagination
- add `process_list.html` template
- link process list from the file selection page
- record start/end time and status in the database

## Testing
- `python -m py_compile app.py`
- `python -m py_compile image_classifier.py`
- `python -m py_compile metashape_script.py` *(warning output)*

------
https://chatgpt.com/codex/tasks/task_e_68695062bea48332b19f916063b17059