### PR TITLE
Load Metashape path from env or config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# GeoSphereAI
+
+This project processes video or image archives using Agisoft Metashape. Before running `app.py` make sure the following configuration is available:
+
+1. **Proxy settings (Windows only)**
+   - The application reads the current user's Windows proxy configuration. The proxy is only applied when running on Windows.
+
+2. **Metashape executable location**
+   - Set the `METASHAPE_EXECUTABLE` environment variable to the path of the Metashape executable, for example:
+     ```bash
+     export METASHAPE_EXECUTABLE="C:\\Program Files\\Agisoft\\Metashape Pro\\metashape.exe"
+     ```
+   - Alternatively create a `config.json` file next to `app.py` with the following structure:
+     ```json
+     {
+       "METASHAPE_EXECUTABLE": "C:/Program Files/Agisoft/Metashape Pro/metashape.exe"
+     }
+     ```
+   - The application will raise an error if the executable path is not found via either method.
+
+Run the application with `python app.py` once these settings have been configured.


### PR DESCRIPTION
## Summary
- guard proxy setup so it runs only on Windows
- load `METASHAPE_EXECUTABLE` from an environment variable or `config.json`
- document configuration steps in a new README

## Testing
- `python3 -m py_compile app.py image_classifier.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6869507b85448332aa40987284e73873