### PR TITLE
Fix SQLAlchemy import error

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ import json
 from threading import Thread
 import sys  # Import sys to get the python executable
 import sqlite3
+from flask_sqlalchemy import SQLAlchemy
 
 if sys.platform.startswith("win"):
     import winreg


### PR DESCRIPTION
## Summary
- add missing `from flask_sqlalchemy import SQLAlchemy`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6869572ab6a08332a7cba321bdc36d79