### PR TITLE
Fix duplicate SQLAlchemy init

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,10 +70,6 @@ app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///processes.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 db = SQLAlchemy(app)
 
-# Database configuration
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///app.db"
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-db = SQLAlchemy(app)
 
 
 class Process(db.Model):


### PR DESCRIPTION
## Summary
- remove second `SQLAlchemy` initialization

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6869588d2a4c833293f44fc460285fbe