### PR TITLE
Fix missing datetime import

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from threading import Thread
 import sys  # Import sys to get the python executable
 import sqlite3
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
 
 if sys.platform.startswith("win"):
     import winreg


### PR DESCRIPTION
## Summary
- import `datetime` to fix missing definition in `video_upload`

## Testing
- `python -m py_compile app.py image_classifier.py metashape_script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869a4f354fc8332b1ab1e02e22a58f7