### PR TITLE
Fix results URL in process list

### DIFF
--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -38,7 +38,7 @@
                     </td>
                     <td>
                         {% if p.status.lower() == 'completed' %}
-                            <a href="{{ url_for('results', process_id=p.id) }}" class="btn-small">مشاهده نتایج</a>
+                            <a href="{{ url_for('results', output_foldername=p.output_folder) }}" class="btn-small">مشاهده نتایج</a>
                         {% elif p.status.lower() == 'processing' %}
                             <a href="{{ url_for('processing', process_id=p.id) }}" class="btn-small">مشاهده پردازش</a>
                         {% endif %}

--- a/templates/processing.html
+++ b/templates/processing.html
@@ -297,10 +297,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     isCompleted = true;
                     clearInterval(updateInterval);
                     addLogEntry('پردازش با موفقیت انجام شد!', 'success');
-                    
+
+                    const outputFolder = data.output_foldername || processId;
                     // Show success message and redirect
                     setTimeout(() => {
-                        window.location.href = `/results/${processId}`;
+                        window.location.href = `/results/${outputFolder}`;
                     }, 3000);
                 }
                 


### PR DESCRIPTION
## Summary
- fix results link to use stored output folder
- redirect to results using server-provided folder name after processing

## Testing
- `python -m py_compile app.py image_classifier.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_686ac2857ebc8332a1c234455d963540