### PR TITLE
Fix download link in results page

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -23,7 +23,7 @@
                             <i class="icon-eye"></i> مشاهده PCD
                         </a>
                     {% endif %}
-                    <a href="{{ url_for('download_file', filename=file) }}" class="btn-download">
+                    <a href="{{ url_for('download', output_foldername=output_foldername, file_path=file) }}" class="btn-download">
                         <i class="icon-download"></i> دریافت
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
- fix URL generation for download links in `templates/results.html`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ac5b1fc8c833291d018d16301b744