### PR TITLE
Remove animation loops from 3D viewers

### DIFF
--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -28,8 +28,8 @@
 
         let camera, scene, renderer, controls;  
         let pointCloud; // Store the point cloud object  
-        init();  
-        animate();  
+        init();
+        render();
 
         function init() {  
             // Renderer  
@@ -48,9 +48,10 @@
             scene.add(camera);  
 
             // Controls  
-            controls = new OrbitControls(camera, renderer.domElement);  
-            controls.enableDamping = true; // an animation loop is required when either damping or auto-rotation are enabled  
-            controls.dampingFactor = 0.05;  
+            controls = new OrbitControls(camera, renderer.domElement);
+            controls.enableDamping = false; // Disabled because there is no animation loop
+            controls.addEventListener('change', render); // Render on interaction
+            controls.dampingFactor = 0.05;
             controls.screenSpacePanning = false;  
             controls.minDistance = 1;  
             controls.maxDistance = 10;  
@@ -114,15 +115,9 @@
             render();  
         }  
 
-        function animate() {  
-            requestAnimationFrame(animate);  
-            controls.update(); // Required if controls.enableDamping or controls.autoRotate are set to true  
-            render();  
-        }  
-
-        function render() {  
-            renderer.render(scene, camera);  
-        }  
+        function render() {
+            renderer.render(scene, camera);
+        }
     </script>  
 </body>  
 </html>

--- a/templates/ply.html
+++ b/templates/ply.html
@@ -28,7 +28,7 @@
         let camera, scene, renderer, controls;
 
         init();
-        animate();
+        render();
 
         function init() {
             scene = new THREE.Scene();
@@ -47,7 +47,7 @@
 
             controls = new OrbitControls(camera, renderer.domElement); // Use imported OrbitControls
             controls.addEventListener('change', render); // Render on interaction
-            controls.enableDamping = true; // Smooth camera movement
+            controls.enableDamping = false; // Damping disabled since no animation loop
             controls.dampingFactor = 0.25;
             controls.screenSpacePanning = false;
             controls.minDistance = 0.1;
@@ -131,12 +131,6 @@
             camera.aspect = window.innerWidth / window.innerHeight;
             camera.updateProjectionMatrix();
             renderer.setSize(window.innerWidth, window.innerHeight);
-            render();
-        }
-
-        function animate() {
-            requestAnimationFrame(animate);
-            controls.update();
             render();
         }
 


### PR DESCRIPTION
## Summary
- redraw point cloud viewers on demand instead of using an endless loop
- hook render calls to OrbitControls changes and disable damping when animation is removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ada1607b483328c0868a0eebf60b3