### PR TITLE
Add point cloud preview generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,6 +330,7 @@ def video_upload():
             os.makedirs(output_dir, exist_ok=True)
 
             classify_images = request.form.get("classify_images") == "on"
+            generate_preview = request.form.get("generate_preview") == "on"
 
             db_process = Process(
                 id=process_id,
@@ -393,6 +394,7 @@ def video_upload():
                 crop_height_ratio,
                 model_format,
                 classify_images,
+                generate_preview,
             ):
                 with app.app_context():
                     try:
@@ -628,6 +630,8 @@ def video_upload():
                             "--output_dir",
                             output_dir,
                         ]
+                        if generate_preview:
+                            metashape_command.extend(["--preview_ratio", "0.1"])
 
                         logging.info(
                             f"Running geoSphereAi command: {' '.join(metashape_command)}"
@@ -741,6 +745,7 @@ def video_upload():
                     crop_height_ratio,
                     model_format,
                     classify_images,
+                    generate_preview,
                 ),
             ).start()
 
@@ -792,6 +797,7 @@ def zip_upload():
         os.makedirs(output_dir, exist_ok=True)
 
         classify_images = request.form.get("classify_images") == "on"
+        generate_preview = request.form.get("generate_preview") == "on"
 
         process_id = str(uuid.uuid4())
         db_process = Process(
@@ -816,7 +822,7 @@ def zip_upload():
             "output_foldername": process_uuid,
         }
 
-        def process_zip_task(process_id, zip_path, output_dir, classify_images):
+        def process_zip_task(process_id, zip_path, output_dir, classify_images, generate_preview):
             with app.app_context():
                 try:
                     image_dir = os.path.join(output_dir, "extracted_images")
@@ -972,6 +978,8 @@ def zip_upload():
                         "--output_dir",
                         output_dir,
                     ]
+                    if generate_preview:
+                        metashape_command.extend(["--preview_ratio", "0.1"])
 
                     logging.info(
                         f"Running Metashape command: {' '.join(metashape_command)}"
@@ -1077,7 +1085,7 @@ def zip_upload():
 
         Thread(
             target=process_zip_task,
-            args=(process_id, zip_path, output_dir, classify_images),
+            args=(process_id, zip_path, output_dir, classify_images, generate_preview),
         ).start()
 
         return redirect(url_for("processing", process_id=process_id))

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -86,6 +86,17 @@
                 </label>
             </div>
 
+            <div class="toggle-group">
+                <label class="toggle-label" for="generate_preview">
+                    <span class="toggle-content">
+                        <span class="toggle-text">تولید نسخه پیش‌نمایش ابر نقاط</span>
+                        <span class="toggle-description">حجم کمتر برای نمایش سریع‌تر</span>
+                    </span>
+                    <input type="checkbox" class="toggle-input" id="generate_preview" name="generate_preview" checked>
+                    <span class="toggle-switch"></span>
+                </label>
+            </div>
+
             <div class="input-group">
                 <label for="crop_height_ratio">درصد برش ارتفاع</label>
                 <div class="range-container">

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -51,6 +51,17 @@
                 </label>
             </div>
 
+            <div class="toggle-group">
+                <label class="toggle-label" for="generate_preview">
+                    <span class="toggle-content">
+                        <span class="toggle-text">تولید نسخه پیش‌نمایش ابر نقاط</span>
+                        <span class="toggle-description">حجم کمتر برای نمایش سریع‌تر</span>
+                    </span>
+                    <input type="checkbox" class="toggle-input" id="generate_preview" name="generate_preview" checked>
+                    <span class="toggle-switch"></span>
+                </label>
+            </div>
+
             <div class="info-box">
                 <div class="info-icon">💡</div>
                 <div class="info-content">


### PR DESCRIPTION
## Summary
- add `downsample_point_cloud` helper to create reduced point clouds
- export preview PLY/PCD when `--preview_ratio` flag is supplied
- support `--preview_ratio` in CLI
- expose preview generation through Flask forms and tasks
- add preview toggle to video and zip upload pages

## Testing
- `python -m py_compile app.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_686ada1abd7c83329db821e5dfc1fdbb