### PR TITLE
Add optional PLY/PCD export flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,13 @@ metashape -r metashape_script.py --image_full_pipeline \
     --image_dir path/to/images --output_dir outputs/run1
 ```
 
+By default the pipeline exports both PLY and PCD point clouds. Use
+`--export_ply` and/or `--export_pcd` to control the formats:
+
+```bash
+metashape -r metashape_script.py --image_full_pipeline \
+    --image_dir path/to/images --output_dir outputs/run1 --export_ply
+```
+
 The web interface performs similar commands internally when you upload files through the browser.
 


### PR DESCRIPTION
## Summary
- allow choosing point cloud export formats in `metashape_script.py`
- document `--export_ply` and `--export_pcd` flags in the README

## Testing
- `python -m py_compile metashape_script.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ae42b163c8332a20e2dc8b80ba5b2