### PR TITLE
Fix Persian labels on viewer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1349,11 +1349,18 @@ def serve_output_file(output_foldername, file_path):
 # Route to provide class labels for the viewer templates
 @app.route("/class_labels")
 def serve_class_labels():
-    config_path = os.path.join(app.root_path, "saved_model", "config.json")
+    lang = request.args.get("lang", "en")
+    if lang == "fa":
+        path = os.path.join(app.root_path, "saved_model", "class_labels_fa.json")
+        key = None
+    else:
+        path = os.path.join(app.root_path, "saved_model", "config.json")
+        key = "id2label"
+
     try:
-        with open(config_path, "r", encoding="utf-8") as cfg:
+        with open(path, "r", encoding="utf-8") as cfg:
             data = json.load(cfg)
-        mapping = data.get("id2label", {})
+        mapping = data if key is None else data.get(key, {})
     except Exception as exc:
         logging.error(f"Failed to load class labels: {exc}")
         mapping = {}

--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -133,7 +133,7 @@
         }).name('Point Size');
 
         const filterContainer = document.getElementById('filterContainer');
-        const response = await fetch('/class_labels');
+        const response = await fetch('/class_labels?lang=fa');
         const labels = await response.json();
         for (const cls in groupObjects) {
             const label = document.createElement('label');

--- a/templates/ply.html
+++ b/templates/ply.html
@@ -125,7 +125,7 @@
                 controls.update();
 
                 const filterContainer = document.getElementById('filterContainer');
-                const response = await fetch('/class_labels');
+                const response = await fetch('/class_labels?lang=fa');
                 const labels = await response.json();
                 for (const cls in groupObjects) {
                     const label = document.createElement('label');


### PR DESCRIPTION
## Summary
- add language switch to class_labels route
- fetch Persian label mapping in PLY and PCD viewer templates

## Testing
- `python -m py_compile app.py image_classifier.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_686af26d2d088332a07bb2d77e821481