### PR TITLE
Fix: hide header on login page

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,7 +268,7 @@ def index():
         else:
             flash("نام کاربری یا کلمه عبور اشتباه است.")
             return redirect(request.url)
-    return render_template("index.html")
+    return render_template("index.html", hide_nav=True)
 
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
 </head>
 <body>
     <!-- Header Navigation -->
+    {% if not hide_nav %}
     <header class="main-header">
         <nav class="main-nav">
             <div class="nav-container">
@@ -45,6 +46,7 @@
             </div>
         </nav>
     </header>
+    {% endif %}
 
     <!-- Main Content -->
     <main class="main-content">
@@ -52,6 +54,7 @@
     </main>
 
     <!-- Footer -->
+    {% if not hide_nav %}
     <footer class="main-footer">
         <div class="footer-container">
             <div class="footer-content">
@@ -67,6 +70,7 @@
             </div>
         </div>
     </footer>
+    {% endif %}
 
     <script>
         function toggleMobileMenu() {


### PR DESCRIPTION
## Summary
- avoid showing navigation on the login screen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e7b5ff4dc8332ad24014f2c0614e9