### PR TITLE
Fix reprocess bug and improve delete button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -703,10 +703,17 @@ ul.process-list li {
     border-radius: 4px;
     display: inline-block;
     transition: background 0.3s ease;
+    margin-right: 4px;
 }
 
 .btn-small:hover {
     background: #0056b3;
+}
+
+.btn-small.disabled {
+    background: #6c757d;
+    pointer-events: none;
+    opacity: 0.6;
 }
 
 /* Pagination Styles */

--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -39,7 +39,7 @@
                     <td>
                         {% if p.status.lower() == 'completed' %}
                             <a href="{{ url_for('results', output_foldername=p.output_folder) }}" class="btn-small">مشاهده نتایج</a>
-                            <a href="{{ url_for('delete_upload', process_id=p.id) }}" class="btn-small">حذف فایل</a>
+                            <a href="{{ url_for('delete_upload', process_id=p.id) }}" class="btn-small{% if not p.has_upload %} disabled{% endif %}" onclick="return confirm('آیا از حذف فایل مطمئن هستید؟');">حذف فایل</a>
                             <a href="{{ url_for('reprocess', process_id=p.id) }}" class="btn-small">پردازش مجدد</a>
                         {% elif p.status.lower() == 'processing' %}
                             <a href="{{ url_for('processing', process_id=p.id) }}" class="btn-small">مشاهده پردازش</a>


### PR DESCRIPTION
## Summary
- show upload existence in process list
- confirm before deleting uploaded file
- disable delete button when file already removed
- copy original file on reprocess to avoid DB constraint
- polish small button style

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e82988a088332aac063714de615eb