### PR TITLE
Add reference preselection modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,13 @@ metashape -r metashape_script.py --image_full_pipeline \
 The web interface performs similar commands internally when you upload files through the browser.
 When uploading a video or ZIP file you can now choose the point cloud formats using checkboxes for **PLY** and **PCD**.
 
+Use the new `--reference_preselection_mode` option to control Metashape's reference preselection strategy. Supported values are `source`, `estimated`, and `sequential`:
+
+```bash
+metashape -r metashape_script.py --image_full_pipeline \
+    --image_dir path/to/images --output_dir outputs/run1 \
+    --reference_preselection_mode sequential
+```
+
+The video and ZIP upload pages expose this setting through a dropdown labeled **حالت پیش‌انتخاب مرجع**.
+

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -96,6 +96,17 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="preselection_mode">حالت پیش‌انتخاب مرجع</label>
+            <div class="select-container">
+                <select name="preselection_mode" id="preselection_mode" class="modern-select">
+                    <option value="source">ReferencePreselectionSource</option>
+                    <option value="estimated">ReferencePreselectionEstimated</option>
+                    <option value="sequential">ReferencePreselectionSequential</option>
+                </select>
+            </div>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -61,6 +61,17 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="preselection_mode">حالت پیش‌انتخاب مرجع</label>
+            <div class="select-container">
+                <select name="preselection_mode" id="preselection_mode" class="modern-select">
+                    <option value="source">ReferencePreselectionSource</option>
+                    <option value="estimated">ReferencePreselectionEstimated</option>
+                    <option value="sequential">ReferencePreselectionSequential</option>
+                </select>
+            </div>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">


### PR DESCRIPTION
## Summary
- let users pick reference preselection mode in upload forms
- propagate choice through processing functions
- support new `--reference_preselection_mode` CLI option
- document option in README

## Testing
- `python -m py_compile app.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6870d8285d8483328575bae9ac77110f