### PR TITLE
Enable sensor type selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,13 @@ metashape -r metashape_script.py --image_full_pipeline \
 
 The video and ZIP upload pages expose this setting through a dropdown labeled **حالت پیش‌انتخاب مرجع**.
 
+Use `--sensor_type` to select the camera model. Allowed values are `Frame`, `Fisheye`, `Spherical`, and `Cylindrical`:
+
+```bash
+metashape -r metashape_script.py --image_full_pipeline \
+    --image_dir path/to/images --output_dir outputs/run1 \
+    --sensor_type Fisheye
+```
+
+The documentation for Metashape (user guide and Python API) is available in `static/docs/`.
+

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -107,6 +107,18 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="sensor_type">نوع دوربین</label>
+            <div class="select-container">
+                <select name="sensor_type" id="sensor_type" class="modern-select">
+                    <option value="Frame">Frame</option>
+                    <option value="Fisheye">Fisheye</option>
+                    <option value="Spherical">Spherical</option>
+                    <option value="Cylindrical">Cylindrical</option>
+                </select>
+            </div>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -72,6 +72,18 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="sensor_type">نوع دوربین</label>
+            <div class="select-container">
+                <select name="sensor_type" id="sensor_type" class="modern-select">
+                    <option value="Frame">Frame</option>
+                    <option value="Fisheye">Fisheye</option>
+                    <option value="Spherical">Spherical</option>
+                    <option value="Cylindrical">Cylindrical</option>
+                </select>
+            </div>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">


### PR DESCRIPTION
## Summary
- add `--sensor_type` option to `metashape_script.py`
- pass sensor type through Flask routes and worker threads
- expose camera type selection in video and ZIP upload forms
- document sensor type option and location of Metashape docs

## Testing
- `python -m py_compile app.py metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_6870ddd1b7048332944fc3ed3dd631fa