### PR TITLE
Improve action button layout with icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -770,7 +770,7 @@ ul.process-list li {
 .file-actions {
     display: flex;
     gap: 0.5rem;
-    flex-wrap: wrap;
+    flex-wrap: nowrap; /* keep actions on a single row */
 }
 
 .btn-viewer {
@@ -801,6 +801,17 @@ ul.process-list li {
     background: #0056b3;
 }
 
+/* Icon based buttons */
+.icon-btn {
+    width: 32px;
+    height: 32px;
+    padding: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+}
+
 /* Icon placeholders (you can replace with actual icons) */
 .icon-eye::before {
     content: "👁 ";
@@ -808,6 +819,14 @@ ul.process-list li {
 
 .icon-download::before {
     content: "⬇ ";
+}
+
+.icon-trash::before {
+    content: "🗑 ";
+}
+
+.icon-refresh::before {
+    content: "🔄 ";
 }
 
 /* Navigation Links Enhancement */

--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -39,11 +39,19 @@
                     <td>
                         <div class="file-actions">
                             {% if p.status.lower() == 'completed' %}
-                                <a href="{{ url_for('results', output_foldername=p.output_folder) }}" class="btn-small">مشاهده نتایج</a>
-                                <a href="{{ url_for('delete_upload', process_id=p.id) }}" class="btn-small{% if not p.has_upload %} disabled{% endif %}" onclick="return confirm('آیا از حذف فایل مطمئن هستید؟');">حذف فایل</a>
-                                <a href="{{ url_for('reprocess', process_id=p.id) }}" class="btn-small">پردازش مجدد</a>
+                                <a href="{{ url_for('results', output_foldername=p.output_folder) }}" class="btn-small icon-btn" title="مشاهده نتایج">
+                                    <i class="icon-eye"></i>
+                                </a>
+                                <a href="{{ url_for('delete_upload', process_id=p.id) }}" class="btn-small icon-btn{% if not p.has_upload %} disabled{% endif %}" title="حذف فایل" onclick="return confirm('آیا از حذف فایل مطمئن هستید؟');">
+                                    <i class="icon-trash"></i>
+                                </a>
+                                <a href="{{ url_for('reprocess', process_id=p.id) }}" class="btn-small icon-btn" title="پردازش مجدد">
+                                    <i class="icon-refresh"></i>
+                                </a>
                             {% elif p.status.lower() == 'processing' %}
-                                <a href="{{ url_for('processing', process_id=p.id) }}" class="btn-small">مشاهده پردازش</a>
+                                <a href="{{ url_for('processing', process_id=p.id) }}" class="btn-small icon-btn" title="مشاهده پردازش">
+                                    <i class="icon-eye"></i>
+                                </a>
                             {% endif %}
                         </div>
                     </td>

--- a/templates/results.html
+++ b/templates/results.html
@@ -15,16 +15,16 @@
                 <h3 class="file-name">{{ file }}</h3>
                 <div class="file-actions">
                     {% if file.lower().endswith('.ply') %}
-                        <a href="{{ url_for('ply', output_foldername=output_foldername, file_path=file) }}" class="btn-viewer" target="_blank">
-                            <i class="icon-eye"></i> مشاهده PLY
+                        <a href="{{ url_for('ply', output_foldername=output_foldername, file_path=file) }}" class="btn-viewer icon-btn" target="_blank" title="مشاهده PLY">
+                            <i class="icon-eye"></i>
                         </a>
                     {% elif file.lower().endswith('.pcd') %}
-                        <a href="{{ url_for('pcd_viewer', output_foldername=output_foldername, file_path=file) }}" class="btn-viewer" target="_blank">
-                            <i class="icon-eye"></i> مشاهده PCD
+                        <a href="{{ url_for('pcd_viewer', output_foldername=output_foldername, file_path=file) }}" class="btn-viewer icon-btn" target="_blank" title="مشاهده PCD">
+                            <i class="icon-eye"></i>
                         </a>
                     {% endif %}
-                    <a href="{{ url_for('download', output_foldername=output_foldername, file_path=file) }}" class="btn-download">
-                        <i class="icon-download"></i> دریافت
+                    <a href="{{ url_for('download', output_foldername=output_foldername, file_path=file) }}" class="btn-download icon-btn" title="دریافت">
+                        <i class="icon-download"></i>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- keep file action buttons on one row and style them as icon buttons
- define icon classes for trash and refresh
- use icon-only buttons with tooltips on results page
- convert process list action buttons to icon-only

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68718124eb3083329ed5ce0bc5a665d6