### PR TITLE
Add delete project action

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ All application data, including user accounts and process records, is stored in 
 single SQLite file named `app.db` in the project directory. On first run the
 application creates a default user `wapco` with password `wapco`.
 
+Completed processes can be removed from the **Previous Processes** page.
+Click the trash icon labeled **حذف پروژه** to delete a project along with its
+attachments and analysis folder.
+
 ## Usage examples
 
 Processing a directory of images from the command line:

--- a/app.py
+++ b/app.py
@@ -1253,6 +1253,37 @@ def delete_upload(process_id):
     return redirect(url_for("process_list"))
 
 
+# Route to completely delete a process and all related files
+@app.route("/delete-process/<process_id>")
+def delete_process(process_id):
+    if not session.get("logged_in"):
+        flash("لطفاً ابتدا وارد شوید.")
+        return redirect(url_for("index"))
+
+    proc = Process.query.get(process_id)
+    if not proc:
+        flash("پردازش مورد نظر یافت نشد.")
+        return redirect(url_for("process_list"))
+
+    upload_dir = os.path.join(app.config["UPLOAD_FOLDER"], proc.process_uuid)
+    output_dir = os.path.join(app.config["OUTPUT_FOLDER"], proc.output_folder)
+
+    try:
+        if os.path.exists(upload_dir):
+            shutil.rmtree(upload_dir)
+        if os.path.exists(output_dir):
+            shutil.rmtree(output_dir)
+
+        db.session.delete(proc)
+        db.session.commit()
+        flash("پروژه و فایل‌های مرتبط حذف شد.")
+    except Exception as exc:
+        logging.error(f"Failed to delete process {process_id}: {exc}")
+        flash("خطا در حذف پروژه.")
+
+    return redirect(url_for("process_list"))
+
+
 # Route to start a new processing using the original uploaded file
 @app.route("/reprocess/<process_id>")
 def reprocess(process_id):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -829,6 +829,10 @@ ul.process-list li {
     content: "🔄 ";
 }
 
+.icon-delete::before {
+    content: "❌ ";
+}
+
 /* Navigation Links Enhancement */
 .navigation-links {
     margin-top: 2rem;

--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -48,6 +48,9 @@
                                 <a href="{{ url_for('reprocess', process_id=p.id) }}" class="btn-small icon-btn" title="پردازش مجدد">
                                     <i class="icon-refresh"></i>
                                 </a>
+                                <a href="{{ url_for('delete_process', process_id=p.id) }}" class="btn-small icon-btn" title="حذف پروژه" onclick="return confirm('آیا از حذف پروژه و تمام فایل‌ها مطمئن هستید؟');">
+                                    <i class="icon-delete"></i>
+                                </a>
                             {% elif p.status.lower() == 'processing' %}
                                 <a href="{{ url_for('processing', process_id=p.id) }}" class="btn-small icon-btn" title="مشاهده پردازش">
                                     <i class="icon-eye"></i>


### PR DESCRIPTION
## Summary
- add `/delete-process/<id>` route to remove uploads, analysis results and DB entry
- show a **حذف پروژه** button on the processes page
- style new button with `icon-delete`
- document how to remove a project in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_688627d4624483329a075b61c1fd9749