### PR TITLE
Add gallery and zip download options

### DIFF
--- a/app.py
+++ b/app.py
@@ -224,6 +224,23 @@ def create_zip_from_dir(directory, zip_name="results.zip"):
         logging.error(f"Error creating zip file {zip_path}: {e}")
         return None
 
+# Helper to create zip containing only specific extensions
+def create_filtered_zip(directory, extensions, zip_name):
+    zip_path = os.path.join(directory, zip_name)
+    try:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for root, _, files in os.walk(directory):
+                for file in files:
+                    if not any(file.lower().endswith(ext) for ext in extensions):
+                        continue
+                    file_path = os.path.join(root, file)
+                    arcname = os.path.relpath(file_path, directory)
+                    zipf.write(file_path, arcname)
+        return zip_path
+    except Exception as e:
+        logging.error(f"Error creating filtered zip {zip_path}: {e}")
+        return None
+
 
 # Helper function to update process state both in-memory and in the database
 def update_process_state(process_id, updates=None, **kwargs):
@@ -1505,6 +1522,44 @@ def download(output_foldername, file_path):
         return redirect(url_for("results", output_foldername=output_foldername))
 
 
+# Download all point clouds as zip
+@app.route("/download_pointcloud_zip/<output_foldername>")
+def download_pointcloud_zip(output_foldername):
+    if not session.get("logged_in"):
+        flash("لطفاً ابتدا وارد شوید.")
+        return redirect(url_for("index"))
+
+    output_dir = os.path.join(app.config["OUTPUT_FOLDER"], output_foldername)
+    zip_path = create_filtered_zip(
+        output_dir,
+        [".ply", ".pcd", ".obj"],
+        "pointclouds.zip",
+    )
+    if zip_path and os.path.exists(zip_path):
+        return send_from_directory(output_dir, "pointclouds.zip", as_attachment=True)
+    flash("فایل فشرده ابر نقاط یافت نشد.")
+    return redirect(url_for("results", output_foldername=output_foldername))
+
+
+# Download all images as zip
+@app.route("/download_images_zip/<output_foldername>")
+def download_images_zip(output_foldername):
+    if not session.get("logged_in"):
+        flash("لطفاً ابتدا وارد شوید.")
+        return redirect(url_for("index"))
+
+    output_dir = os.path.join(app.config["OUTPUT_FOLDER"], output_foldername)
+    zip_path = create_filtered_zip(
+        output_dir,
+        [".jpg", ".jpeg", ".png"],
+        "images.zip",
+    )
+    if zip_path and os.path.exists(zip_path):
+        return send_from_directory(output_dir, "images.zip", as_attachment=True)
+    flash("فایل فشرده تصاویر یافت نشد.")
+    return redirect(url_for("results", output_foldername=output_foldername))
+
+
 # New route for displaying PLY files
 @app.route("/ply/<output_foldername>/<path:file_path>")
 def ply(output_foldername, file_path):
@@ -1555,6 +1610,33 @@ def pcd_viewer(output_foldername, file_path):
     else:
         flash("pcd file not found.")
         return redirect(url_for("results", output_foldername=output_foldername))
+
+
+# Gallery route to display frames and blended images
+@app.route("/gallery/<output_foldername>")
+def gallery(output_foldername):
+    if not session.get("logged_in"):
+        flash("لطفاً ابتدا وارد شوید.")
+        return redirect(url_for("index"))
+
+    output_dir = os.path.join(app.config["OUTPUT_FOLDER"], output_foldername)
+    frames_dir = os.path.join(output_dir, "frames")
+    blended_dir = os.path.join(output_dir, "blended_images")
+
+    frames = []
+    if os.path.isdir(frames_dir):
+        frames = [f for f in os.listdir(frames_dir) if allowed_file(f, app.config["ALLOWED_IMAGE_EXTENSIONS"])]
+
+    blended = []
+    if os.path.isdir(blended_dir):
+        blended = [f for f in os.listdir(blended_dir) if allowed_file(f, app.config["ALLOWED_IMAGE_EXTENSIONS"])]
+
+    return render_template(
+        "gallery.html",
+        output_foldername=output_foldername,
+        frames=frames,
+        blended_images=blended,
+    )
 
 
 # Static route for serving files within the output folder (e.g., for viewers)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -801,13 +801,13 @@ ul.process-list li {
 
 /* Icon based buttons */
 .icon-btn {
-    width: 32px;
-    height: 32px;
-    padding: 6px;
+    width: 48px;
+    height: 48px;
+    padding: 10px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1rem;
+    font-size: 1.25rem;
 }
 
 /* Icon placeholders (you can replace with actual icons) */
@@ -841,4 +841,17 @@ ul.process-list li {
 
 .navigation-links .back-link {
     margin-left: 1rem;
+}
+
+/* Gallery Grid */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-grid img {
+    width: 100%;
+    border-radius: 8px;
+    object-fit: cover;
 }

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}گالری نتایج{% endblock %}
+
+{% block content %}
+<div class="container">
+    <h2>گالری تصاویر</h2>
+
+    <h3>فریم‌ها</h3>
+    <div class="gallery-grid">
+        {% for img in frames %}
+        <img src="{{ url_for('serve_output_file', output_foldername=output_foldername, file_path='frames/' + img) }}" alt="frame">
+        {% endfor %}
+    </div>
+
+    <h3>تصاویر طبقه‌بندی‌شده</h3>
+    <div class="gallery-grid">
+        {% for img in blended_images %}
+        <img src="{{ url_for('serve_output_file', output_foldername=output_foldername, file_path='blended_images/' + img) }}" alt="blended">
+        {% endfor %}
+    </div>
+
+    <div class="navigation-links">
+        <a href="{{ url_for('results', output_foldername=output_foldername) }}" class="back-link">بازگشت به نتایج</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -6,8 +6,14 @@
 {% block content %}
 <div class="container">
     <h2>نتایج پردازش</h2>
-    <p>پردازش با موفقیت کامل شد. فایل‌های زیر برای دانلود آماده هستند:</p>
-    
+    <p>پردازش با موفقیت کامل شد.</p>
+
+    <div class="button-group">
+        <a href="{{ url_for('download_pointcloud_zip', output_foldername=output_foldername) }}" class="btn">دانلود ابر نقاط (ZIP)</a>
+        <a href="{{ url_for('download_images_zip', output_foldername=output_foldername) }}" class="btn">دانلود تصاویر (ZIP)</a>
+        <a href="{{ url_for('gallery', output_foldername=output_foldername) }}" class="btn">مشاهده گالری</a>
+    </div>
+
     <div class="results-grid">
         {% for file in file_paths %}
         <div class="result-item">
@@ -23,9 +29,6 @@
                             <i class="icon-eye"></i>
                         </a>
                     {% endif %}
-                    <a href="{{ url_for('download', output_foldername=output_foldername, file_path=file) }}" class="btn-download icon-btn" title="دریافت">
-                        <i class="icon-download"></i>
-                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- enlarge viewer buttons and add gallery CSS
- show zip download and gallery buttons on results page
- create gallery template for frames and blended images
- add helper to create filtered zip archives
- add routes for zip downloads and gallery page

## Testing
- `python -m py_compile app.py >/tmp/py_compile.log && tail -n 20 /tmp/py_compile.log`

------
https://chatgpt.com/codex/tasks/task_e_68862e088c20833296dd35d208427eac