### PR TITLE
Fix point cloud export argument

### DIFF
--- a/metashape_script.py
+++ b/metashape_script.py
@@ -207,7 +207,7 @@ def convert_to_point_cloud(project_path, output_dir, preview_ratio=None, export_
                 crs=chunk.crs,  # Coordinate Reference System
                 binary=True,
                 save_point_classification=True,
-                save_colors=True
+                save_point_color=True
             )
             print(f"ply Point cloud exported to {output_path}")
 
@@ -218,7 +218,7 @@ def convert_to_point_cloud(project_path, output_dir, preview_ratio=None, export_
                 format=Metashape.PointCloudFormatPCD,  # Point cloud format (pcd)
                 crs=chunk.crs,  # Coordinate Reference System
                 binary=True,
-                save_colors=True
+                save_point_color=True
             )
             print(f"pcd Point cloud exported to {output_path}")
 


### PR DESCRIPTION
## Summary
- use `save_point_color` when exporting point cloud

## Testing
- `python -m py_compile metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_688a83c2b65c8332954f72b9bd5792e4