### PR TITLE
Fix class ID extraction in point cloud viewers

### DIFF
--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -88,7 +88,7 @@
 
         if (colAttr) {
             const col = colAttr.array;
-            if (col[0] > 1) colorScale = 255;
+            colorScale = colAttr.array.BYTES_PER_ELEMENT === 1 ? 255 : 1;
             for (let i = 0; i < total; i++) {
                 const classId = Math.round(colorScale === 255 ?
                     col[i * 3 + 1] : col[i * 3 + 1] * 255);

--- a/templates/ply.html
+++ b/templates/ply.html
@@ -82,7 +82,7 @@
 
                 if (colAttr) {
                     const col = colAttr.array;
-                    if (col[0] > 1) colorScale = 255;
+                    colorScale = colAttr.array.BYTES_PER_ELEMENT === 1 ? 255 : 1;
                     for (let i = 0; i < total; i++) {
                         const classId = Math.round(colorScale === 255 ?
                             col[i * 3 + 1] : col[i * 3 + 1] * 255);


### PR DESCRIPTION
## Summary
- Correctly detect whether color attributes are 8-bit or normalized to extract class IDs accurately in PLY/PCD viewers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892fdc9317883328366bae40a257791