### PR TITLE
Add hole-filling post processing step for segmentation masks

### DIFF
--- a/image_classifier.py
+++ b/image_classifier.py
@@ -10,6 +10,7 @@ import logging
 from tqdm import tqdm
 import matplotlib.pyplot as plt  # Import matplotlib for colormap
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from scipy import ndimage
 
 # Configure TensorFlow to utilise GPU when available
 # gpus = tf.config.list_physical_devices('GPU')
@@ -124,6 +125,51 @@ def apply_neighborhood_smoothing(mask: np.ndarray, kernel_size: int = 3, num_cla
     return smoothed.numpy().astype(mask.dtype)
 
 
+def fill_holes_in_class(
+    mask: np.ndarray,
+    target_classes,
+    structure_size: int = 3,
+    area_threshold: int = 0,
+) -> np.ndarray:
+    """Fill internal holes within specified classes of a segmentation mask.
+
+    Args:
+        mask: 2D array of class indices.
+        target_classes: Iterable of class IDs for which holes should be filled.
+        structure_size: Size of the structuring element used for hole filling.
+        area_threshold: Maximum area (in pixels) of holes to fill. If 0, all holes
+            are filled regardless of size.
+
+    Returns:
+        np.ndarray: Mask with holes in the target classes filled.
+    """
+
+    # Copy to avoid modifying the input array in-place
+    filled_mask = mask.copy()
+    structure = np.ones((structure_size, structure_size), dtype=bool)
+
+    for cls in target_classes:
+        class_region = filled_mask == cls
+        # Fill holes inside the class region
+        filled_region = ndimage.binary_fill_holes(class_region, structure=structure)
+        holes = filled_region & (~class_region)
+
+        if area_threshold > 0:
+            # Keep only holes smaller than the area threshold
+            labeled, num_features = ndimage.label(holes)
+            small_holes = np.zeros_like(holes, dtype=bool)
+            for i in range(1, num_features + 1):
+                region = labeled == i
+                if np.sum(region) <= area_threshold:
+                    small_holes |= region
+            holes = small_holes
+
+        # Assign the surrounding class to the hole pixels
+        filled_mask[holes] = cls
+
+    return filled_mask
+
+
 def classify_image(image_path, model_name: str = DEFAULT_MODEL_NAME):
     """Classifies a single image and returns the predicted segmentation mask (numpy array)."""
     if model is None or feature_extractor is None or loaded_model_name != model_name:
@@ -151,6 +197,11 @@ def classify_image(image_path, model_name: str = DEFAULT_MODEL_NAME):
 
         # Apply neighbourhood smoothing to reduce isolated class outliers
         predicted_mask = apply_neighborhood_smoothing(predicted_mask)
+
+        # Fill small holes for selected classes (e.g., floor=3, road=6)
+        predicted_mask = fill_holes_in_class(
+            predicted_mask, target_classes=[3, 6], structure_size=3, area_threshold=50
+        )
 
         return predicted_mask
 


### PR DESCRIPTION
## Summary
- add `fill_holes_in_class` to remove internal holes inside specified classes
- apply hole filling after neighbourhood smoothing in `classify_image`

## Testing
- `python -m py_compile image_classifier.py`
- `python - <<'PY'
import numpy as np, re
from scipy import ndimage
code = open('image_classifier.py').read()
match = re.search(r"def fill_holes_in_class[\s\S]*?return filled_mask", code)
ns = {'np':np, 'ndimage':ndimage}
exec(match.group(0), ns)
fill_holes_in_class = ns['fill_holes_in_class']
mask = np.array([[3,3,3,3,3],[3,0,0,0,3],[3,0,6,0,3],[3,0,0,0,3],[3,3,3,3,3]])
filled = fill_holes_in_class(mask, target_classes=[3,6], structure_size=3, area_threshold=50)
print('original')
print(mask)
print('filled')
print(filled)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689321195dfc8332b18b93aac696da42