### PR TITLE
feat: add optional reference file

### DIFF
--- a/app.py
+++ b/app.py
@@ -372,6 +372,16 @@ def video_upload():
             video_path = os.path.join(upload_process_dir, filename)
             file.save(video_path)
 
+            reference_file = request.files.get("reference_file")
+            reference_file_path = None
+            if reference_file and reference_file.filename:
+                reference_file.stream.seek(0, os.SEEK_END)
+                if reference_file.stream.tell() > 0:
+                    reference_file.stream.seek(0)
+                    ref_filename = secure_filename(reference_file.filename)
+                    reference_file_path = os.path.join(upload_process_dir, ref_filename)
+                    reference_file.save(reference_file_path)
+
             process_id = str(uuid.uuid4())
             output_dir = os.path.join(app.config["OUTPUT_FOLDER"], process_id)
             os.makedirs(output_dir, exist_ok=True)
@@ -452,6 +462,7 @@ def video_upload():
                 export_pcd,
                 preselection_mode,
                 sensor_type,
+                reference_file_path,
             ):
                 with app.app_context():
                     try:
@@ -699,6 +710,8 @@ def video_upload():
                             "--sensor_type",
                             sensor_type,
                         ])
+                        if reference_file_path:
+                            metashape_command.extend(["--reference_file", reference_file_path])
                         if generate_preview:
                             metashape_command.extend(["--preview_ratio", "0.1"])
                         if export_ply:
@@ -827,6 +840,7 @@ def video_upload():
                     export_pcd,
                     preselection_mode,
                     sensor_type,
+                    reference_file_path,
                 ),
             ).start()
 
@@ -874,6 +888,16 @@ def zip_upload():
             flash("مشکلی در ذخیره‌سازی فایل ZIP رخ داد.")
             return redirect(request.url)
 
+        reference_file = request.files.get("reference_file")
+        reference_file_path = None
+        if reference_file and reference_file.filename:
+            reference_file.stream.seek(0, os.SEEK_END)
+            if reference_file.stream.tell() > 0:
+                reference_file.stream.seek(0)
+                ref_filename = secure_filename(reference_file.filename)
+                reference_file_path = os.path.join(upload_process_dir, ref_filename)
+                reference_file.save(reference_file_path)
+
         output_dir = os.path.join(app.config["OUTPUT_FOLDER"], process_uuid)
         os.makedirs(output_dir, exist_ok=True)
 
@@ -919,6 +943,7 @@ def zip_upload():
             segformer_model,
             preselection_mode,
             sensor_type,
+            reference_file_path,
         ):
             with app.app_context():
                 try:
@@ -1083,6 +1108,8 @@ def zip_upload():
                         "--sensor_type",
                         sensor_type,
                     ])
+                    if reference_file_path:
+                        metashape_command.extend(["--reference_file", reference_file_path])
                     if generate_preview:
                         metashape_command.extend(["--preview_ratio", "0.1"])
                     if export_ply:
@@ -1207,6 +1234,7 @@ def zip_upload():
                 segformer_model,
                 preselection_mode,
                 sensor_type,
+                reference_file_path,
             ),
         ).start()
 

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -246,6 +246,7 @@ def process_in_metashape(
     output_dir,
     reference_preselection_mode="source",
     sensor_type="Frame",
+    reference_file=None,
 ):
     import Metashape
     
@@ -276,6 +277,14 @@ def process_in_metashape(
         ]
     )
     print(f"Loaded {len(chunk.cameras)} images")
+
+    if reference_file:
+        try:
+            chunk.importReference(path=reference_file, format=Metashape.ReferenceFormatCSV)
+            chunk.crs = Metashape.CoordinateSystem("EPSG::4326")
+            print(f"Reference data imported from {reference_file}")
+        except Exception as e:
+            print(f"Failed to import reference file: {e}")
 
     # Set sensor type for all sensors
     type_map = {
@@ -472,10 +481,15 @@ if __name__ == "__main__":
         if "--sensor_type" in sys.argv
         else "Frame"
     )
-    if "--extract_frames" in sys.argv:  
-        # Extract frames from video  
-        video_path = sys.argv[sys.argv.index("--extract_frames") + 1]  
-        image_dir = sys.argv[sys.argv.index("--image_dir") + 1]  
+    reference_file = (
+        sys.argv[sys.argv.index("--reference_file") + 1]
+        if "--reference_file" in sys.argv
+        else None
+    )
+    if "--extract_frames" in sys.argv:
+        # Extract frames from video
+        video_path = sys.argv[sys.argv.index("--extract_frames") + 1]
+        image_dir = sys.argv[sys.argv.index("--image_dir") + 1]
         start_time = float(sys.argv[sys.argv.index("--start_time") + 1]) if "--start_time" in sys.argv else 0  
         end_time = float(sys.argv[sys.argv.index("--end_time") + 1]) if "--end_time" in sys.argv else None  
         frame_interval = float(sys.argv[sys.argv.index("--frame_interval") + 1]) if "--frame_interval" in sys.argv else 1  
@@ -488,7 +502,7 @@ if __name__ == "__main__":
         image_dir = sys.argv[sys.argv.index("--image_dir") + 1]
         output_dir = sys.argv[sys.argv.index("--output_dir") + 1]
         process_in_metashape(
-            image_dir, output_dir, reference_preselection_mode, sensor_type
+            image_dir, output_dir, reference_preselection_mode, sensor_type, reference_file
         )
 
     if "--convert_to_point_cloud" in sys.argv:  
@@ -508,7 +522,7 @@ if __name__ == "__main__":
         image_dir = sys.argv[sys.argv.index("--image_dir") + 1]
         output_dir = sys.argv[sys.argv.index("--output_dir") + 1]
         process_in_metashape(
-            image_dir, output_dir, reference_preselection_mode, sensor_type
+            image_dir, output_dir, reference_preselection_mode, sensor_type, reference_file
         )
         
         # Convert to point cloud  
@@ -539,10 +553,10 @@ if __name__ == "__main__":
             crop_height_ratio=crop_height_ratio  
         )  
 
-        # Process in Metashape  
-        metashape_output_dir = os.path.join(output_base_dir, "project")  
+        # Process in Metashape
+        metashape_output_dir = os.path.join(output_base_dir, "project")
         process_in_metashape(
-            image_dir, metashape_output_dir, reference_preselection_mode, sensor_type
+            image_dir, metashape_output_dir, reference_preselection_mode, sensor_type, reference_file
         )
 
         # Convert to point cloud  

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -119,6 +119,12 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="reference_file">فایل مختصات <span style="font-weight: normal;">(اختیاری)</span></label>
+            <input type="file" name="reference_file" id="reference_file">
+            <small>در صورت عدم انتخاب فایل، پردازش بدون مختصات ادامه می‌یابد.</small>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -84,6 +84,12 @@
             </div>
         </div>
 
+        <div class="input-group">
+            <label for="reference_file">فایل مختصات <span style="font-weight: normal;">(اختیاری)</span></label>
+            <input type="file" name="reference_file" id="reference_file">
+            <small>در صورت عدم انتخاب فایل، پردازش بدون مختصات ادامه می‌یابد.</small>
+        </div>
+
             <div class="toggle-group">
                 <label class="toggle-label" for="generate_preview">
                     <span class="toggle-content">


### PR DESCRIPTION
## Summary
- allow optional coordinate file upload for zip and video forms
- pass reference file to processing only when provided
- support `--reference_file` in metashape_script and import coordinates conditionally

## Testing
- `python -m py_compile app.py metashape_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b70129f7e88332846de765041746ff