### PR TITLE
Specify delimiter for reference import

### DIFF
--- a/metashape_script.py
+++ b/metashape_script.py
@@ -280,7 +280,11 @@ def process_in_metashape(
 
     if reference_file:
         try:
-            chunk.importReference(path=reference_file, format=Metashape.ReferenceFormatCSV)
+            chunk.importReference(
+                path=reference_file,
+                format=Metashape.ReferenceFormatCSV,
+                delimiter=",",
+            )
             chunk.crs = Metashape.CoordinateSystem("EPSG::4326")
             print(f"Reference data imported from {reference_file}")
         except Exception as e:


### PR DESCRIPTION
## Summary
- specify CSV delimiter when importing reference data

## Testing
- `python -m py_compile metashape_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68b70721978883329dc492278ca07ae7