### PR TITLE
Enable point size attenuation in point cloud viewer

### DIFF
--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -603,7 +603,7 @@
                     geometry.rotateY(0);
                     geometry.center();
                     
-                    const material = new THREE.PointsMaterial({ size: 2, vertexColors: true });
+                    const material = new THREE.PointsMaterial({ size: 0.02, vertexColors: true, sizeAttenuation: true });
                     const points = new THREE.Points(geometry, material);
                     processPointCloud(points);
                     resolve(points);
@@ -788,7 +788,7 @@
                 geometry.rotateY(0);
                 geometry.center();
                 
-                const material = new THREE.PointsMaterial({ size: 2, vertexColors: true });
+                const material = new THREE.PointsMaterial({ size: 0.02, vertexColors: true, sizeAttenuation: true });
                 const points = new THREE.Points(geometry, material);
                 processPointCloud(points);
             }, undefined, function(error) {


### PR DESCRIPTION
## Summary
- Reduce point size in Three.js viewer and enable size attenuation for realistic depth appearance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b811f1ff2883329b547d21247f37c1