### PR TITLE
Fix preview URL generation in viewers

### DIFF
--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -489,8 +489,9 @@
 
         // تولید URL های احتمالی
         function generatePossibleUrls(outputFoldername, filePath, prefix = '') {
-           
-            return [`/outputs/${outputFoldername}/${filePath}`];
+            const url = `/outputs/${outputFoldername}/${filePath}`;
+            const previewUrl = url.replace(/(\.ply|\.pcd)$/i, '_preview$1');
+            return [url, previewUrl];
         }
 
         // تلاش برای بارگذاری با URL های مختلف

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -492,8 +492,9 @@
 
         // تولید URL های احتمالی
         function generatePossibleUrls(outputFoldername, filePath, prefix = '') {
-
-            return [`/outputs/${outputFoldername}/${filePath}`];
+            const url = `/outputs/${outputFoldername}/${filePath}`;
+            const previewUrl = url.replace(/(\.ply|\.pcd)$/i, '_preview$1');
+            return [url, previewUrl];
         }
 
         // تلاش برای بارگذاری با URL های مختلف


### PR DESCRIPTION
## Summary
- Generate both original and preview URLs in `generatePossibleUrls`
- Ensure preview names use regex to avoid extra dots

## Testing
- `node -e '["point_cloud.ply","point_cloud.pcd","POINT_CLOUD.PLY"].forEach(f=>console.log(f+" -> "+f.replace(/(\.ply|\.pcd)$/i,"_preview$1")));'`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b895105710833296ac8203f2cf70b9