### PR TITLE
Preserve class and label fields in preview point clouds

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,7 +41,11 @@ else:
 
 # Import the new image classifier module
 import image_classifier
-from metashape_script import downsample_point_cloud, validate_ply_file
+from metashape_script import (
+    downsample_point_cloud,
+    validate_ply_file,
+    add_class_field_to_ply,
+)
 
 
 def apply_windows_proxy():
@@ -1646,6 +1650,10 @@ def ply(output_foldername, file_path):
             if not os.path.exists(preview_path):
                 try:
                     downsample_point_cloud(full_file_path, preview_path, ratio=0.1)
+                    add_class_field_to_ply(preview_path)
+                    preview_with_class = preview_path.replace('.ply', '_with_class.ply')
+                    if os.path.exists(preview_with_class):
+                        os.replace(preview_with_class, preview_path)
                     validate_ply_file(preview_path)
                 except Exception as exc:
                     logging.warning(f"Failed to create preview PLY: {exc}")

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -444,11 +444,19 @@ def convert_to_point_cloud(project_path, output_dir, preview_ratio=None, export_
                 preview_path = os.path.join(output_dir, "point_cloud_preview.ply")
                 if os.path.exists(ply_path):
                     downsample_point_cloud(ply_path, preview_path, preview_ratio)
+                    add_class_field_to_ply(preview_path)
+                    preview_with_class = preview_path.replace('.ply', '_with_class.ply')
+                    if os.path.exists(preview_with_class):
+                        os.replace(preview_with_class, preview_path)
             if export_pcd:
                 pcd_path = os.path.join(output_dir, "point_cloud.pcd")
                 preview_pcd = os.path.join(output_dir, "point_cloud_preview.pcd")
                 if os.path.exists(pcd_path):
                     downsample_point_cloud(pcd_path, preview_pcd, preview_ratio)
+                    add_class_field_to_pcd(preview_pcd)
+                    preview_pcd_with_class = preview_pcd.replace('.pcd', '_with_class.pcd')
+                    if os.path.exists(preview_pcd_with_class):
+                        os.replace(preview_pcd_with_class, preview_pcd)
     
     except Exception as e:  
         print(f"Error exporting point cloud: {e}") 


### PR DESCRIPTION
## Summary
- After downsampling PLY files for previews, copy the green channel into `class` and `label` fields in `app.py`
- Apply the same classification field injection for preview PLY and PCD files generated in `metashape_script.py`

## Testing
- `python -m py_compile app.py metashape_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b95e6cb53083329e91d6f01c019457