### PR TITLE
Add Potree viewer integration and link

### DIFF
--- a/app.py
+++ b/app.py
@@ -1533,6 +1533,14 @@ def results(output_foldername):
 
     logging.info(f"Found {len(file_paths)} relevant files in results directory.")
 
+    # Detect Potree output by searching for cloud.js
+    potree_path = None
+    for subdir, _, files in os.walk(output_dir):
+        if "cloud.js" in files:
+            potree_path = os.path.relpath(os.path.join(subdir, "cloud.js"), output_dir)
+            potree_path = potree_path.replace("\\", "/")
+            break
+
     original_filename = "Processed Files"
     process = Process.query.filter_by(output_folder=output_foldername).first()
     if process:
@@ -1551,6 +1559,7 @@ def results(output_foldername):
         filename=original_filename,
         output_foldername=output_foldername,
         file_paths=file_paths,
+        potree_path=potree_path,
     )
 
 
@@ -1703,6 +1712,19 @@ def pcd_viewer(output_foldername, file_path):
     else:
         flash("pcd file not found.")
         return redirect(url_for("results", output_foldername=output_foldername))
+
+
+# Route to display Potree point clouds
+@app.route("/potree/<output_foldername>/<path:potree_file_path>")
+def potree_viewer(output_foldername, potree_file_path):
+    if not session.get("logged_in"):
+        flash("لطفاً ابتدا وارد شوید.")
+        return redirect(url_for("index"))
+
+    cloud_js_url = url_for(
+        "serve_output_file", output_foldername=output_foldername, file_path=potree_file_path
+    )
+    return render_template("potree_viewer.html", cloud_js_url=cloud_js_url)
 
 
 # Gallery route to display frames and blended images

--- a/templates/potree_viewer.html
+++ b/templates/potree_viewer.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="fa">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>نمایش Potree</title>
+    <!-- Potree CSS -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/potree.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/jquery-ui/jquery-ui.min.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/perfect-scrollbar/css/perfect-scrollbar.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/openlayers3/ol.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/spectrum/spectrum.css" />
+</head>
+<body>
+    <div class="potree_container" style="position:absolute;width:100%;height:100%;left:0;top:0;">
+        <div id="potree_render_area" style="width:100%;height:100%;"></div>
+        <div id="potree_sidebar_container"></div>
+    </div>
+
+    <!-- Potree and dependencies -->
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/jquery/jquery-3.1.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/spectrum/spectrum.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/jquery-ui/jquery-ui.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/perfect-scrollbar/js/perfect-scrollbar.jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/other/BinaryHeap.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/tween/tween.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/d3/d3.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/proj4/proj4.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/openlayers3/ol.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/i18next/i18next.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/potree.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/potree/potree@1.8/build/potree/libs/plasio/js/laslaz.js"></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const viewer = new Potree.Viewer(document.getElementById('potree_render_area'));
+            viewer.setEDLEnabled(true);
+            viewer.setFOV(60);
+            viewer.setPointBudget(1000000);
+
+            Potree.loadPointCloud('{{ cloud_js_url }}', 'cloud', function (e) {
+                const pointcloud = e.pointcloud;
+                viewer.scene.addPointCloud(pointcloud);
+                viewer.fitToScreen();
+            });
+        });
+    </script>
+</body>
+</html>

--- a/templates/results.html
+++ b/templates/results.html
@@ -7,16 +7,19 @@
     <h2>نتایج پردازش</h2>
     <p>پردازش با موفقیت کامل شد.</p>
 
-    <div class="button-group">
-        <a href="{{ url_for('gallery', output_foldername=output_foldername) }}" class="btn">مشاهده گالری</a>
-        <a href="{{ url_for('download_pointcloud_zip', output_foldername=output_foldername) }}"
-            class="btn btn-download">
-            <i class="icon-download"></i>دانلود همه ابرنقاط
-        </a>
-        <a href="{{ url_for('download_images_zip', output_foldername=output_foldername) }}" class="btn btn-download">
-            <i class="icon-download"></i>دانلود همه تصاویر
-        </a>
-    </div>
+      <div class="button-group">
+          <a href="{{ url_for('gallery', output_foldername=output_foldername) }}" class="btn">مشاهده گالری</a>
+          <a href="{{ url_for('download_pointcloud_zip', output_foldername=output_foldername) }}"
+              class="btn btn-download">
+              <i class="icon-download"></i>دانلود همه ابرنقاط
+          </a>
+          <a href="{{ url_for('download_images_zip', output_foldername=output_foldername) }}" class="btn btn-download">
+              <i class="icon-download"></i>دانلود همه تصاویر
+          </a>
+          {% if potree_path %}
+          <a href="{{ url_for('potree_viewer', output_foldername=output_foldername, potree_file_path=potree_path) }}" class="btn" target="_blank">نمایش در Potree</a>
+          {% endif %}
+      </div>
 
     <div class="results-grid">
         {% for file in file_paths %}


### PR DESCRIPTION
## Summary
- detect Potree output folders and expose cloud.js path to results template
- add route and template for viewing point clouds with Potree
- link Potree viewer from results page for easy access

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b986949f688332a4add7cb997f65aa