### PR TITLE
Ensure complete Potree export and file serving

### DIFF
--- a/app.py
+++ b/app.py
@@ -1763,8 +1763,15 @@ def potree_viewer(output_foldername):
 
     potree_dir = os.path.join(app.config["OUTPUT_FOLDER"], output_foldername, "potree")
     cloud_js = os.path.join(potree_dir, "cloud.js")
-    if os.path.exists(cloud_js):
+    data_exists = any(
+        os.path.isdir(os.path.join(potree_dir, d)) and d.lower().startswith("data")
+        for d in os.listdir(potree_dir)
+    ) if os.path.isdir(potree_dir) else False
+
+    if os.path.exists(cloud_js) and data_exists:
         return render_template("potree_viewer.html", output_foldername=output_foldername)
+
+    logging.error(f"Incomplete Potree output for {output_foldername} at {potree_dir}")
     flash("Potree output not found.")
     return redirect(url_for("results", output_foldername=output_foldername))
 
@@ -1772,21 +1779,20 @@ def potree_viewer(output_foldername):
 @app.route("/potree/<output_foldername>/<path:filename>")
 def potree_file(output_foldername, filename):
     potree_dir = os.path.join(app.config["OUTPUT_FOLDER"], output_foldername, "potree")
-    full_path = os.path.join(potree_dir, filename)
+    safe_path = os.path.abspath(os.path.join(potree_dir, filename))
 
-    if not os.path.abspath(full_path).startswith(os.path.abspath(potree_dir)):
+    if not safe_path.startswith(os.path.abspath(potree_dir)):
         logging.warning(
             f"Attempted directory traversal in potree route: {output_foldername}/{filename}"
         )
         return "Unauthorized", 401
 
-    if os.path.exists(full_path) and os.path.isfile(full_path):
-        directory = os.path.dirname(full_path)
-        file_name = os.path.basename(full_path)
-        return send_from_directory(directory, file_name)
-    else:
-        flash("Potree file not found.")
-        return redirect(url_for("results", output_foldername=output_foldername))
+    if os.path.isfile(safe_path):
+        return send_from_directory(potree_dir, filename)
+
+    logging.error(f"Potree file not found: {safe_path}")
+    flash("Potree file not found.")
+    return redirect(url_for("results", output_foldername=output_foldername))
 
 
 # Gallery route to display frames and blended images

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -10,6 +10,9 @@ metashape -r "D:\AI\3dRecognition\pycode\metashaspe-v3.py" --create_and_export_3
 '''  
 import os
 import sys
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
 def downsample_point_cloud(input_path, output_path, ratio=0.1):
@@ -419,15 +422,32 @@ def convert_to_point_cloud(
         if export_potree:
             potree_dir = os.path.join(output_dir, "potree")
             os.makedirs(potree_dir, exist_ok=True)
-            potree_path = os.path.join(potree_dir, "cloud.js")
             chunk.exportPointCloud(
-                potree_path,
+                potree_dir,
                 format=Metashape.PointCloudFormatPotree,
                 crs=Metashape.CoordinateSystem("EPSG::32640"), #chunk.crs,
                 save_point_classification=True,
                 save_point_color=True,
             )
-            print(f"Potree point cloud exported to {potree_path}")
+
+            cloud_js = os.path.join(potree_dir, "cloud.js")
+            data_dirs = [
+                d
+                for d in os.listdir(potree_dir)
+                if os.path.isdir(os.path.join(potree_dir, d)) and d.lower().startswith("data")
+            ]
+
+            if not os.path.exists(cloud_js) or not data_dirs:
+                missing = []
+                if not os.path.exists(cloud_js):
+                    missing.append("cloud.js")
+                if not data_dirs:
+                    missing.append("data folder")
+                logging.error(
+                    f"Incomplete Potree export at {potree_dir}: missing {', '.join(missing)}"
+                )
+            else:
+                print(f"Potree point cloud exported to {potree_dir}")
 
         if preview_ratio:
             if export_ply:


### PR DESCRIPTION
## Summary
- Export Potree point clouds into the output directory so Metashape generates the full structure.
- Validate Potree exports for `cloud.js` and data folders, logging errors when incomplete.
- Harden Flask routes for Potree viewer and file serving with structure checks and safer path handling.

## Testing
- `python -m py_compile metashape_script.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68baf7baab308332a22ba5bff74776ef