### PR TITLE
Add optional analysis framework with sign bounding box

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,26 @@ metashape -r metashape_script.py --image_full_pipeline \
 
 The documentation for Metashape (user guide and Python API) is available in `static/docs/`.
 
+## Optional analyses
+
+The sign processing pipeline supports optional analysis steps. Use
+`sign_pipeline.available_analyses()` to list the registered analyses and
+pass the desired names to `process_sign_pipeline` via the `analyses`
+parameter. For example:
+
+```python
+from sign_pipeline import process_sign_pipeline
+
+process_sign_pipeline(
+    image_dir="images",
+    output_dir="outputs/run1",
+    analyses=["sign_bbox"],
+)
+```
+
+The provided `sign_bbox` analysis computes a bounding box around traffic
+sign points (label `43`) and writes the results to `sign_bboxes.json` in
+the output directory. When uploading a ZIP or video through the web
+interface, available analyses appear under **تحلیل‌های اختیاری** so users
+can select them without writing code.
+

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+"""Registry and utility functions for optional point cloud analyses.
+
+This module allows registering analysis functions and exposing them to the
+application so that users can select which analyses to run. Each analysis
+is a callable that accepts a point cloud path and optional keyword
+arguments. Results are typically written to JSON files in the same
+output directory.
+"""
+
+from typing import Callable, Dict, List, Any
+import os
+import json
+
+_ANALYSES: Dict[str, Dict[str, Any]] = {}
+
+
+def register_analysis(name: str, description: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a new analysis.
+
+    Parameters
+    ----------
+    name:
+        Unique identifier for the analysis.
+    description:
+        Human readable description presented to the user.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        _ANALYSES[name] = {"func": func, "description": description}
+        return func
+
+    return decorator
+
+
+def list_available() -> List[Dict[str, str]]:
+    """Return metadata for all registered analyses.
+
+    Returns
+    -------
+    list of dict
+        Each dictionary contains ``name`` and ``description`` keys.
+    """
+
+    return [
+        {"name": key, "description": value["description"]}
+        for key, value in _ANALYSES.items()
+    ]
+
+
+def run_analysis(name: str, *args: Any, **kwargs: Any) -> Any:
+    """Execute a registered analysis by *name*.
+
+    Raises
+    ------
+    ValueError
+        If *name* does not correspond to a registered analysis.
+    """
+
+    entry = _ANALYSES.get(name)
+    if not entry:
+        raise ValueError(f"Unknown analysis: {name}")
+    return entry["func"](*args, **kwargs)
+
+
+@register_analysis("sign_bbox", "Compute bounding box for traffic signs (label=43).")
+def compute_sign_bounding_box(ply_path: str, output_dir: str, label_value: int = 43) -> List[Dict[str, float]]:
+    """Generate a bounding box around points with the given *label_value*.
+
+    The point cloud must contain ``label`` field. Results are written to a
+    ``sign_bboxes.json`` file in ``output_dir`` and also returned.
+    """
+    try:
+        from plyfile import PlyData
+        import numpy as np
+    except Exception as exc:  # pragma: no cover - dependencies may be missing
+        raise RuntimeError(f"Required dependency missing for analysis: {exc}") from exc
+
+    ply = PlyData.read(ply_path)
+    vertex = ply["vertex"]
+    if "label" not in vertex.data.dtype.names:
+        raise RuntimeError("Point cloud lacks 'label' field needed for analysis")
+
+    mask = vertex["label"] == label_value
+    if mask.sum() == 0:
+        results: List[Dict[str, float]] = []
+    else:
+        pts = np.vstack((vertex["x"], vertex["y"], vertex["z"])).T[mask]
+        min_xyz = pts.min(axis=0)
+        max_xyz = pts.max(axis=0)
+        size = max_xyz - min_xyz
+        results = [
+            {
+                "label": int(label_value),
+                "min": min_xyz.tolist(),
+                "max": max_xyz.tolist(),
+                "size": size.tolist(),
+            }
+        ]
+
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, "sign_bboxes.json")
+    with open(out_path, "w", encoding="utf-8") as fh:
+        json.dump(results, fh, ensure_ascii=False, indent=2)
+    return results

--- a/app.py
+++ b/app.py
@@ -399,6 +399,7 @@ def video_upload():
             export_ply = "export_ply" in request.form
             export_pcd = "export_pcd" in request.form
             export_potree = "export_potree" in request.form
+            selected_analyses = request.form.getlist("analyses")
 
             db_process = Process(
                 id=process_id,
@@ -474,6 +475,7 @@ def video_upload():
                 preselection_mode,
                 sensor_type,
                 reference_file_path,
+                analyses,
             ):
                 with app.app_context():
                     try:
@@ -797,7 +799,9 @@ def video_upload():
 
                         try:
                             sign_summary = sign_pipeline.process_sign_pipeline(
-                                images_to_process_dir, output_dir
+                                images_to_process_dir,
+                                output_dir,
+                                analyses=analyses,
                             )
                             if sign_summary:
                                 proc_db = Process.query.get(process_id)
@@ -861,18 +865,23 @@ def video_upload():
                     segformer_model,
                     classify_images,
                     generate_preview,
-                export_ply,
-                export_pcd,
-                export_potree,
-                preselection_mode,
-                sensor_type,
-                reference_file_path,
-            ),
+                    export_ply,
+                    export_pcd,
+                    export_potree,
+                    preselection_mode,
+                    sensor_type,
+                    reference_file_path,
+                    selected_analyses,
+                ),
             ).start()
 
             return redirect(url_for("processing", process_id=process_id))
 
-    return render_template("video_upload.html", segformer_models=SEGFORMER_MODELS)
+    return render_template(
+        "video_upload.html",
+        segformer_models=SEGFORMER_MODELS,
+        analyses=sign_pipeline.available_analyses(),
+    )
 
 
 # ZIP upload page
@@ -935,6 +944,7 @@ def zip_upload():
         segformer_model = request.form.get("segformer_model", DEFAULT_SEGFORMER_MODEL)
         preselection_mode = request.form.get("preselection_mode", "source")
         sensor_type = request.form.get("sensor_type", "Frame")
+        selected_analyses = request.form.getlist("analyses")
 
         process_id = str(uuid.uuid4())
         db_process = Process(
@@ -973,6 +983,7 @@ def zip_upload():
             preselection_mode,
             sensor_type,
             reference_file_path,
+            analyses,
         ):
             with app.app_context():
                 try:
@@ -1213,7 +1224,9 @@ def zip_upload():
 
                     try:
                         sign_summary = sign_pipeline.process_sign_pipeline(
-                            images_to_process_dir, output_dir
+                            images_to_process_dir,
+                            output_dir,
+                            analyses=analyses,
                         )
                         if sign_summary:
                             proc_db = Process.query.get(process_id)
@@ -1279,12 +1292,17 @@ def zip_upload():
                 preselection_mode,
                 sensor_type,
                 reference_file_path,
+                selected_analyses,
             ),
         ).start()
 
         return redirect(url_for("processing", process_id=process_id))
 
-    return render_template("zip_upload.html", segformer_models=SEGFORMER_MODELS)
+    return render_template(
+        "zip_upload.html",
+        segformer_models=SEGFORMER_MODELS,
+        analyses=sign_pipeline.available_analyses(),
+    )
 
 
 # New processing page route
@@ -1592,6 +1610,12 @@ def results(output_foldername):
         except Exception as e:
             logging.warning(f"Failed to read sign summary: {e}")
 
+    analysis_files = [
+        f
+        for f in os.listdir(output_dir)
+        if f.endswith(".json") and f != "signs.json"
+    ]
+
     return render_template(
         "results.html",
         filename=original_filename,
@@ -1599,6 +1623,7 @@ def results(output_foldername):
         file_paths=file_paths,
         potree_exists=potree_exists,
         sign_summary=sign_summary,
+        analysis_files=analysis_files,
 
     )
 

--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import os
 import json
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from metashape_script import add_class_field_to_ply
+import analysis
 
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png"}
 
@@ -42,7 +43,9 @@ def _summarise(detections: List[Dict[str, str]]) -> Dict[str, int]:
     return summary
 
 
-def process_sign_pipeline(image_dir: str, output_dir: str) -> Dict[str, int]:
+def process_sign_pipeline(
+    image_dir: str, output_dir: str, analyses: Optional[List[str]] = None
+) -> Dict[str, int]:
     """Run the sign detection pipeline.
 
     Args:
@@ -62,12 +65,18 @@ def process_sign_pipeline(image_dir: str, output_dir: str) -> Dict[str, int]:
     if summary:
         json_path = os.path.join(output_dir, "signs.json")
         with open(json_path, "w", encoding="utf-8") as fh:
-            json.dump({"detections": detections, "summary": summary}, fh, ensure_ascii=False, indent=2)
+            json.dump(
+                {"detections": detections, "summary": summary},
+                fh,
+                ensure_ascii=False,
+                indent=2,
+            )
 
         # Locate first PLY point cloud and add classification fields
+        ply_path = None
         for root, _, files in os.walk(output_dir):
             for file in files:
-                if file.lower().endswith('.ply') and not file.lower().endswith('_with_class.ply'):
+                if file.lower().endswith(".ply") and not file.lower().endswith("_with_class.ply"):
                     ply_path = os.path.join(root, file)
                     try:
                         add_class_field_to_ply(ply_path)
@@ -78,4 +87,16 @@ def process_sign_pipeline(image_dir: str, output_dir: str) -> Dict[str, int]:
                 continue
             break
 
+        if analyses and ply_path:
+            for name in analyses:
+                try:
+                    analysis.run_analysis(name, ply_path, output_dir)
+                except Exception:
+                    pass
+
     return summary
+
+
+def available_analyses() -> List[Dict[str, str]]:
+    """Expose registered analysis options for user selection."""
+    return analysis.list_available()

--- a/templates/results.html
+++ b/templates/results.html
@@ -32,6 +32,17 @@
     </div>
     {% endif %}
 
+    {% if analysis_files %}
+    <div class="analysis-results">
+        <h3>خروجی تحلیل‌ها</h3>
+        <ul>
+            {% for file in analysis_files %}
+            <li><a href="{{ url_for('download', output_foldername=output_foldername, file_path=file) }}">{{ file }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
+
     <div class="results-grid">
         {% for file in file_paths %}
         {% if file.lower().endswith('.ply') or file.lower().endswith('.pcd') %}

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -184,6 +184,16 @@
                     <label><input type="checkbox" name="export_potree"> Potree</label>
                 </div>
             </div>
+            {% if analyses %}
+            <div class="input-group">
+                <label>تحلیل‌های اختیاری</label>
+                <div class="checkbox-group">
+                    {% for a in analyses %}
+                    <label><input type="checkbox" name="analyses" value="{{ a.name }}"> {{ a.description }}</label>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
         </div>
 
         <!-- دکمه ارسال -->

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -110,6 +110,17 @@
                 </div>
             </div>
 
+            {% if analyses %}
+            <div class="input-group">
+                <label>تحلیل‌های اختیاری</label>
+                <div class="checkbox-group">
+                    {% for a in analyses %}
+                    <label><input type="checkbox" name="analyses" value="{{ a.name }}"> {{ a.description }}</label>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+
             <div class="info-box">
                 <div class="info-icon">💡</div>
                 <div class="info-content">


### PR DESCRIPTION
## Summary
- add analysis registry module with pluggable analyses
- update sign pipeline to run selected analyses and expose available options
- document optional analysis usage in README
- allow selecting analyses from upload pages and display analysis outputs in results

## Testing
- `python -m py_compile analysis.py sign_pipeline.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68baf9857c4c83329ff01429e2a7828a