### PR TITLE
Add Open3D worker bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ export HTTP_PROXY=http://proxy.example.com:8080
 export HTTPS_PROXY=http://proxy.example.com:8080
 ```
 
+### Using Open3D
+
+The default environment for GeoSphereAI uses Python 3.7, which is too old for
+`open3d`.  To enable Open3D features such as point‑cloud downsampling and
+validation, install Open3D in a separate Python environment (e.g. Python 3.11)
+and set the path to its interpreter via the `GEO3D_PY` environment variable:
+
+```bash
+export GEO3D_PY=/path/to/python-with-open3d
+```
+
+When `GEO3D_PY` is set, Open3D operations are executed through the helper
+script `o3d_worker.py` in that external environment.
+
 ## Starting the application
 
 Run the Flask server from the project directory:

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -12,6 +12,13 @@ import os
 import sys
 import logging
 import shutil
+from typing import Any, Dict
+
+try:
+    # Local helper to invoke Open3D in an external Python environment
+    from open3d_bridge import run_o3d_worker
+except Exception:  # pragma: no cover - bridge is optional at runtime
+    run_o3d_worker = None  # type: ignore
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
@@ -20,22 +27,33 @@ def downsample_point_cloud(input_path, output_path, ratio=0.1):
     """Create a simplified preview of a point cloud using Open3D."""
     try:
         import open3d as o3d
+
+        if ratio <= 0 or ratio >= 1:
+            raise ValueError("ratio must be between 0 and 1")
+
+        pcd = o3d.io.read_point_cloud(input_path)
+        if len(pcd.points) == 0:
+            print("No points found in point cloud for downsampling")
+            return False
+
+        sampled = pcd.random_down_sample(ratio)
+        o3d.io.write_point_cloud(output_path, sampled)
+        print(f"Preview point cloud saved to {output_path}")
+        return True
     except Exception as exc:
-        print(f"Open3D not available for downsampling: {exc}")
-        return False
-
-    if ratio <= 0 or ratio >= 1:
-        raise ValueError("ratio must be between 0 and 1")
-
-    pcd = o3d.io.read_point_cloud(input_path)
-    if len(pcd.points) == 0:
-        print("No points found in point cloud for downsampling")
-        return False
-
-    sampled = pcd.random_down_sample(ratio)
-    o3d.io.write_point_cloud(output_path, sampled)
-    print(f"Preview point cloud saved to {output_path}")
-    return True
+        if run_o3d_worker is None:
+            print(f"Open3D not available for downsampling: {exc}")
+            return False
+        try:
+            res: Dict[str, Any] = run_o3d_worker("downsample", input_path, output_path, ratio)
+            if not res.get("ok"):
+                print(f"Open3D worker failed: {res}")
+                return False
+            print(f"Preview point cloud saved to {output_path}")
+            return True
+        except Exception as worker_exc:
+            print(f"Open3D worker not available: {worker_exc}")
+            return False
 
 
 def validate_ply_file(ply_path):
@@ -72,7 +90,19 @@ def validate_ply_file(ply_path):
                     f"Point count mismatch: header {actual_count}, Open3D {len(pcd.points)}"
                 )
         except Exception as exc:
-            print(f"Open3D validation skipped: {exc}")
+            if run_o3d_worker is not None:
+                try:
+                    res: Dict[str, Any] = run_o3d_worker("count", ply_path)
+                    if res.get("ok") and res.get("points") != actual_count:
+                        print(
+                            f"Point count mismatch: header {actual_count}, Open3D {res.get('points')}"
+                        )
+                    elif not res.get("ok"):
+                        print(f"Open3D worker error: {res}")
+                except Exception as worker_exc:
+                    print(f"Open3D validation skipped: {worker_exc}")
+            else:
+                print(f"Open3D validation skipped: {exc}")
 
         fields = vertex.data.dtype.names
         print(

--- a/o3d_worker.py
+++ b/o3d_worker.py
@@ -1,0 +1,37 @@
+import json
+import sys
+import open3d as o3d
+
+
+def downsample(in_path: str, out_path: str, ratio: float):
+    pcd = o3d.io.read_point_cloud(in_path)
+    sampled = pcd.random_down_sample(ratio)
+    o3d.io.write_point_cloud(out_path, sampled)
+    return {"ok": True, "points_before": len(pcd.points), "points_after": len(sampled.points)}
+
+
+def count_points(ply_path: str):
+    pcd = o3d.io.read_point_cloud(ply_path)
+    return {"ok": True, "points": len(pcd.points)}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(json.dumps({"ok": False, "error": "usage"}))
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+    try:
+        if cmd == "downsample" and len(sys.argv) >= 5:
+            in_ply = sys.argv[2]
+            out_ply = sys.argv[3]
+            ratio = float(sys.argv[4])
+            result = downsample(in_ply, out_ply, ratio)
+        elif cmd == "count" and len(sys.argv) >= 3:
+            result = count_points(sys.argv[2])
+        else:
+            result = {"ok": False, "error": "invalid args"}
+    except Exception as exc:
+        result = {"ok": False, "error": str(exc)}
+    print(json.dumps(result))
+    sys.exit(0 if result.get("ok") else 1)

--- a/open3d_bridge.py
+++ b/open3d_bridge.py
@@ -1,0 +1,31 @@
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Dict
+
+# Path to Python interpreter with Open3D installed. Set via environment variable.
+GEO3D_PY = os.environ.get("GEO3D_PY")
+
+# Path to the worker script (same directory as this file by default)
+O3D_WORKER = os.path.join(os.path.dirname(__file__), "o3d_worker.py")
+
+
+def run_o3d_worker(*args: str) -> Dict[str, Any]:
+    """Run the Open3D worker in the external environment.
+
+    If the ``GEO3D_PY`` environment variable is set, that interpreter is used.
+    Otherwise ``sys.executable`` is used as a fallback.
+    Returns the parsed JSON output from the worker, or a dict with ``raw_stdout``
+    if the output is not JSON.
+    """
+
+    interpreter = GEO3D_PY or sys.executable
+    cmd = [interpreter, O3D_WORKER, *map(str, args)]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise RuntimeError("o3d_worker failed:\n" + (res.stderr or res.stdout))
+    try:
+        return json.loads(res.stdout.strip())
+    except Exception:
+        return {"ok": True, "raw_stdout": res.stdout}


### PR DESCRIPTION
## Summary
- Introduce `open3d_bridge` and `o3d_worker` scripts to run Open3D tasks in an external Python environment.
- Update point-cloud utilities to fallback to the worker when Open3D isn't locally available.
- Document how to configure the external Open3D environment via `GEO3D_PY`.

## Testing
- `python -m py_compile open3d_bridge.py o3d_worker.py metashape_script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb1959eddc83329d95f8405e503d62