### PR TITLE
Ensure sign analysis uses class-enriched PLY

### DIFF
--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -80,6 +80,9 @@ def process_sign_pipeline(
                     ply_path = os.path.join(root, file)
                     try:
                         add_class_field_to_ply(ply_path)
+                        with_class = os.path.splitext(ply_path)[0] + "_with_class.ply"
+                        if os.path.exists(with_class):
+                            ply_path = with_class
                     except Exception:
                         pass
                     break


### PR DESCRIPTION
## Summary
- use the `_with_class.ply` file when running optional analyses so label-based tasks like `sign_bbox` can execute

## Testing
- `python -m py_compile sign_pipeline.py analysis.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb362fed408332b23260eb2ec55f6d