### PR TITLE
Handle optional classification output

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ metashape -r metashape_script.py --image_full_pipeline \
     --image_dir path/to/images --output_dir outputs/run1 --export_ply
 ```
 
+Include the optional `--add_class_field` flag to duplicate the colour channel
+into ``class`` and ``label`` fields within exported point clouds. The web
+interface automatically enables this when SegFormer classification is selected.
+
 The web interface performs similar commands internally when you upload files through the browser.
 When uploading a video or ZIP file you can now choose the point cloud formats using checkboxes for **PLY** and **PCD**.
 

--- a/app.py
+++ b/app.py
@@ -737,6 +737,8 @@ def video_upload():
                             metashape_command.append("--export_pcd")
                         if export_potree:
                             metashape_command.append("--export_potree")
+                        if classify_images:
+                            metashape_command.append("--add_class_field")
 
                         logging.info(
                             f"Running geoSphereAi command: {' '.join(metashape_command)}"
@@ -806,8 +808,9 @@ def video_upload():
                                 images_to_process_dir,
                                 output_dir,
                                 analyses=analyses,
+                                add_class_field=classify_images,
                             )
-                            if sign_summary:
+                            if classify_images and sign_summary:
                                 proc_db = Process.query.get(process_id)
                                 if proc_db:
                                     proc_db.has_classification = 1
@@ -1166,6 +1169,8 @@ def zip_upload():
                         metashape_command.append("--export_pcd")
                     if export_potree:
                         metashape_command.append("--export_potree")
+                    if classify_images:
+                        metashape_command.append("--add_class_field")
 
                     logging.info(
                         f"Running Metashape command: {' '.join(metashape_command)}"
@@ -1235,8 +1240,9 @@ def zip_upload():
                             images_to_process_dir,
                             output_dir,
                             analyses=analyses,
+                            add_class_field=classify_images,
                         )
-                        if sign_summary:
+                        if classify_images and sign_summary:
                             proc_db = Process.query.get(process_id)
                             if proc_db:
                                 proc_db.has_classification = 1

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -441,7 +441,8 @@ def convert_to_point_cloud(
                 save_point_classification=True,
                 save_point_color=True,
             )
-            add_class_field_to_ply(output_path)
+            if add_class_field:
+                add_class_field_to_ply(output_path)
             print(f"ply Point cloud exported to {output_path}")
 
         if export_pcd:
@@ -453,7 +454,8 @@ def convert_to_point_cloud(
                 binary=True,
                 save_point_color=True
             )
-            add_class_field_to_pcd(output_path)
+            if add_class_field:
+                add_class_field_to_pcd(output_path)
             print(f"pcd Point cloud exported to {output_path}")
             
         if export_potree:
@@ -493,19 +495,21 @@ def convert_to_point_cloud(
                 preview_path = os.path.join(output_dir, "point_cloud_preview.ply")
                 if os.path.exists(ply_path):
                     downsample_point_cloud(ply_path, preview_path, preview_ratio)
-                    add_class_field_to_ply(preview_path)
-                    preview_with_class = preview_path.replace('.ply', '_with_class.ply')
-                    if os.path.exists(preview_with_class):
-                        os.replace(preview_with_class, preview_path)
+                    if add_class_field:
+                        add_class_field_to_ply(preview_path)
+                        preview_with_class = preview_path.replace('.ply', '_with_class.ply')
+                        if os.path.exists(preview_with_class):
+                            os.replace(preview_with_class, preview_path)
             if export_pcd:
                 pcd_path = os.path.join(output_dir, "point_cloud.pcd")
                 preview_pcd = os.path.join(output_dir, "point_cloud_preview.pcd")
                 if os.path.exists(pcd_path):
                     downsample_point_cloud(pcd_path, preview_pcd, preview_ratio)
-                    add_class_field_to_pcd(preview_pcd)
-                    preview_pcd_with_class = preview_pcd.replace('.pcd', '_with_class.pcd')
-                    if os.path.exists(preview_pcd_with_class):
-                        os.replace(preview_pcd_with_class, preview_pcd)
+                    if add_class_field:
+                        add_class_field_to_pcd(preview_pcd)
+                        preview_pcd_with_class = preview_pcd.replace('.pcd', '_with_class.pcd')
+                        if os.path.exists(preview_pcd_with_class):
+                            os.replace(preview_pcd_with_class, preview_pcd)
 
 
     except Exception as e:
@@ -576,6 +580,7 @@ if __name__ == "__main__":
     export_ply = "--export_ply" in sys.argv
     export_pcd = "--export_pcd" in sys.argv
     export_potree = "--export_potree" in sys.argv
+    add_class_field = "--add_class_field" in sys.argv
     if not export_ply and not export_pcd and not export_potree:
         export_ply = export_pcd = True
     reference_preselection_mode = (

--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -44,7 +44,10 @@ def _summarise(detections: List[Dict[str, str]]) -> Dict[str, int]:
 
 
 def process_sign_pipeline(
-    image_dir: str, output_dir: str, analyses: Optional[List[str]] = None
+    image_dir: str,
+    output_dir: str,
+    analyses: Optional[List[str]] = None,
+    add_class_field: bool = True,
 ) -> Dict[str, int]:
     """Run the sign detection pipeline.
 
@@ -52,9 +55,10 @@ def process_sign_pipeline(
         image_dir: Directory containing the images that were processed by
             Metashape.
         output_dir: Directory containing the point cloud outputs. A JSON file
-        named ``signs.json`` will be written here describing the detected
-        signs. If a PLY file is present a new file with added ``class`` and
-        ``label`` fields will be generated alongside it.
+            named ``signs.json`` will be written here describing the detected
+            signs. If *add_class_field* is True and a PLY file is present, a new
+            file with added ``class`` and ``label`` fields will be generated
+            alongside it.
 
     Returns:
         A dictionary summarising the counts of detected sign classes.
@@ -72,19 +76,20 @@ def process_sign_pipeline(
                 indent=2,
             )
 
-        # Locate first PLY point cloud and add classification fields
+        # Locate first PLY point cloud and optionally add classification fields
         ply_path = None
         for root, _, files in os.walk(output_dir):
             for file in files:
                 if file.lower().endswith(".ply") and not file.lower().endswith("_with_class.ply"):
                     ply_path = os.path.join(root, file)
-                    try:
-                        add_class_field_to_ply(ply_path)
-                        with_class = os.path.splitext(ply_path)[0] + "_with_class.ply"
-                        if os.path.exists(with_class):
-                            ply_path = with_class
-                    except Exception:
-                        pass
+                    if add_class_field:
+                        try:
+                            add_class_field_to_ply(ply_path)
+                            with_class = os.path.splitext(ply_path)[0] + "_with_class.ply"
+                            if os.path.exists(with_class):
+                                ply_path = with_class
+                        except Exception:
+                            pass
                     break
             else:
                 continue


### PR DESCRIPTION
## Summary
- Allow Metashape export to skip class/label fields unless `--add_class_field` is provided
- Let the sign pipeline optionally add class fields and wire the option through the web app
- Document the new `--add_class_field` CLI flag

## Testing
- `python -m py_compile metashape_script.py sign_pipeline.py app.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbf376f0f8833289e778e88a3163c5