### PR TITLE
Improve point cloud format selectors and preview UI

### DIFF
--- a/static/css/video-upload.css
+++ b/static/css/video-upload.css
@@ -230,6 +230,48 @@
     height: 14px;
 }
 
+/* Mode selection buttons */
+.mode-options {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.mode-option input {
+    display: none;
+}
+
+.mode-option span {
+    display: inline-block;
+    padding: 8px 16px;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    color: #495057;
+    background: #fff;
+    font-weight: 500;
+}
+
+.mode-option span:hover {
+    border-color: #007bff;
+}
+
+.mode-option input:checked + span {
+    background: #007bff;
+    color: #fff;
+    border-color: #007bff;
+}
+
+.preview-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: #495057;
+}
+
 /* Fixed Toggle Switch for RTL */
 .toggle-group {
     background: #f8f9fa;

--- a/static/css/zip-upload.css
+++ b/static/css/zip-upload.css
@@ -142,6 +142,115 @@
     transform: translateX(-24px);
 }
 
+/* Range slider */
+.range-container {
+    position: relative;
+    padding: 1rem 0;
+}
+
+.range-display {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.range-current-value {
+    display: inline-block;
+    background: #007bff;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: bold;
+    font-size: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 123, 255, 0.3);
+}
+
+.range-wrapper {
+    position: relative;
+    padding: 0 10px;
+    direction: rtl;
+}
+
+.modern-range {
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: #e9ecef;
+    outline: none;
+    -webkit-appearance: none;
+    position: relative;
+    z-index: 2;
+    direction: rtl;
+}
+
+.modern-range::-webkit-slider-thumb {
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #007bff;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 123, 255, 0.3);
+    transition: all 0.3s ease;
+    border: 2px solid white;
+}
+
+.modern-range::-webkit-slider-thumb:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.4);
+}
+
+.modern-range::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #007bff;
+    cursor: pointer;
+    border: 2px solid white;
+    box-shadow: 0 2px 8px rgba(0, 123, 255, 0.3);
+}
+
+/* Mode selection buttons */
+.mode-options {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.mode-option input {
+    display: none;
+}
+
+.mode-option span {
+    display: inline-block;
+    padding: 8px 16px;
+    border: 2px solid #e9ecef;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    color: #495057;
+    background: #fff;
+    font-weight: 500;
+}
+
+.mode-option span:hover {
+    border-color: #007bff;
+}
+
+.mode-option input:checked + span {
+    background: #007bff;
+    color: #fff;
+    border-color: #007bff;
+}
+
+.preview-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: #495057;
+}
+
 /* Info Box */
 .info-box {
     background: linear-gradient(135deg, #e8f5e8 0%, #f0f8f0 100%);

--- a/templates/video_upload.html
+++ b/templates/video_upload.html
@@ -186,27 +186,55 @@
             </div>
             <div class="input-group">
                 <label for="ply_mode">حالت PLY</label>
-                <div class="select-container">
-                    <select name="ply_mode" id="ply_mode" class="modern-select">
-                        <option value="binary" selected>binary</option>
-                        <option value="ascii">ascii</option>
-                        <option value="both">both</option>
-                    </select>
+                <div class="mode-options">
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="binary" checked>
+                        <span>binary</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="ascii">
+                        <span>ascii</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="both">
+                        <span>both</span>
+                    </label>
                 </div>
-                <label><input type="checkbox" name="ply_preview"> پیش‌نمایش PLY</label>
-                <input type="number" name="ply_preview_pct" min="1" max="100" placeholder="٪" style="width:80px;">
+                <label class="preview-toggle"><input type="checkbox" name="ply_preview"> پیش‌نمایش PLY</label>
+                <div class="range-container">
+                    <div class="range-display">
+                        <span class="range-current-value" id="ply-preview-display">50٪</span>
+                    </div>
+                    <div class="range-wrapper">
+                        <input type="range" name="ply_preview_pct" min="1" max="100" value="50" class="modern-range" oninput="updatePreviewValue(this.value, 'ply-preview-display')">
+                    </div>
+                </div>
             </div>
             <div class="input-group">
                 <label for="pcd_mode">حالت PCD</label>
-                <div class="select-container">
-                    <select name="pcd_mode" id="pcd_mode" class="modern-select">
-                        <option value="binary" selected>binary</option>
-                        <option value="ascii">ascii</option>
-                        <option value="both">both</option>
-                    </select>
+                <div class="mode-options">
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="binary" checked>
+                        <span>binary</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="ascii">
+                        <span>ascii</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="both">
+                        <span>both</span>
+                    </label>
                 </div>
-                <label><input type="checkbox" name="pcd_preview"> پیش‌نمایش PCD</label>
-                <input type="number" name="pcd_preview_pct" min="1" max="100" placeholder="٪" style="width:80px;">
+                <label class="preview-toggle"><input type="checkbox" name="pcd_preview"> پیش‌نمایش PCD</label>
+                <div class="range-container">
+                    <div class="range-display">
+                        <span class="range-current-value" id="pcd-preview-display">50٪</span>
+                    </div>
+                    <div class="range-wrapper">
+                        <input type="range" name="pcd_preview_pct" min="1" max="100" value="50" class="modern-range" oninput="updatePreviewValue(this.value, 'pcd-preview-display')">
+                    </div>
+                </div>
             </div>
             {% if analyses %}
             <div class="input-group">
@@ -243,6 +271,10 @@ function updateFrameInterval(value) {
 function updateCropRatio(value) {
     const percentage = Math.round(parseFloat(value) * 100);
     document.getElementById('crop-ratio-display').textContent = percentage + '%';
+}
+
+function updatePreviewValue(value, id) {
+    document.getElementById(id).textContent = value + '٪';
 }
 
 // File upload functionality

--- a/templates/zip_upload.html
+++ b/templates/zip_upload.html
@@ -111,27 +111,55 @@
             </div>
             <div class="input-group">
                 <label for="ply_mode">حالت PLY</label>
-                <div class="select-container">
-                    <select name="ply_mode" id="ply_mode" class="modern-select">
-                        <option value="binary" selected>binary</option>
-                        <option value="ascii">ascii</option>
-                        <option value="both">both</option>
-                    </select>
+                <div class="mode-options">
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="binary" checked>
+                        <span>binary</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="ascii">
+                        <span>ascii</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="ply_mode" value="both">
+                        <span>both</span>
+                    </label>
                 </div>
-                <label><input type="checkbox" name="ply_preview"> پیش‌نمایش PLY</label>
-                <input type="number" name="ply_preview_pct" min="1" max="100" placeholder="٪" style="width:80px;">
+                <label class="preview-toggle"><input type="checkbox" name="ply_preview"> پیش‌نمایش PLY</label>
+                <div class="range-container">
+                    <div class="range-display">
+                        <span class="range-current-value" id="ply-preview-display">50٪</span>
+                    </div>
+                    <div class="range-wrapper">
+                        <input type="range" name="ply_preview_pct" min="1" max="100" value="50" class="modern-range" oninput="updatePreviewValue(this.value, 'ply-preview-display')">
+                    </div>
+                </div>
             </div>
             <div class="input-group">
                 <label for="pcd_mode">حالت PCD</label>
-                <div class="select-container">
-                    <select name="pcd_mode" id="pcd_mode" class="modern-select">
-                        <option value="binary" selected>binary</option>
-                        <option value="ascii">ascii</option>
-                        <option value="both">both</option>
-                    </select>
+                <div class="mode-options">
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="binary" checked>
+                        <span>binary</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="ascii">
+                        <span>ascii</span>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" name="pcd_mode" value="both">
+                        <span>both</span>
+                    </label>
                 </div>
-                <label><input type="checkbox" name="pcd_preview"> پیش‌نمایش PCD</label>
-                <input type="number" name="pcd_preview_pct" min="1" max="100" placeholder="٪" style="width:80px;">
+                <label class="preview-toggle"><input type="checkbox" name="pcd_preview"> پیش‌نمایش PCD</label>
+                <div class="range-container">
+                    <div class="range-display">
+                        <span class="range-current-value" id="pcd-preview-display">50٪</span>
+                    </div>
+                    <div class="range-wrapper">
+                        <input type="range" name="pcd_preview_pct" min="1" max="100" value="50" class="modern-range" oninput="updatePreviewValue(this.value, 'pcd-preview-display')">
+                    </div>
+                </div>
             </div>
 
             {% if analyses %}
@@ -173,6 +201,10 @@
 </div>
 
 <script>
+function updatePreviewValue(value, id) {
+    document.getElementById(id).textContent = value + '٪';
+}
+
 // File upload functionality
 document.addEventListener('DOMContentLoaded', function() {
     const fileInput = document.getElementById('zip');


### PR DESCRIPTION
## Summary
- Replace PLY/PCD format dropdowns with button-style radio groups
- Add range sliders with live percentage display for PLY/PCD previews
- Style new selectors and sliders for video and ZIP upload pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc248ba1008332b8856483b46507dd