### PR TITLE
Add global flag to toggle PLY validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,6 +47,7 @@ from metashape_script import (
     add_class_field_to_ply,
 )
 import sign_pipeline
+from settings import ENABLE_PLY_VALIDATION
 
 
 def apply_windows_proxy():
@@ -832,6 +833,7 @@ def video_upload():
                                 output_dir,
                                 analyses=analyses,
                                 add_class_field=classify_images,
+                                validate=ENABLE_PLY_VALIDATION,
                             )
                             if classify_images and sign_summary:
                                 proc_db = Process.query.get(process_id)
@@ -1291,6 +1293,7 @@ def zip_upload():
                             output_dir,
                             analyses=analyses,
                             add_class_field=classify_images,
+                            validate=ENABLE_PLY_VALIDATION,
                         )
                         if classify_images and sign_summary:
                             proc_db = Process.query.get(process_id)
@@ -1779,10 +1782,13 @@ def ply(output_foldername, file_path):
         return redirect(url_for("results", output_foldername=output_foldername))
 
     if os.path.exists(full_file_path) and os.path.isfile(full_file_path):
-        try:
-            validate_ply_file(full_file_path)
-        except Exception as exc:
-            logging.warning(f"PLY validation failed for {full_file_path}: {exc}")
+        if ENABLE_PLY_VALIDATION:  # Integrity check; can slow down large files
+            try:
+                validate_ply_file(full_file_path)
+            except Exception as exc:
+                logging.warning(
+                    f"PLY validation failed for {full_file_path}: {exc}"
+                )
 
         options_path = os.path.join(output_dir, "options.json")
         generate_preview = False
@@ -1807,10 +1813,13 @@ def ply(output_foldername, file_path):
                 try:
                     downsample_point_cloud(full_file_path, preview_path, ratio=0.1)
                     add_class_field_to_ply(preview_path)
-                    preview_with_class = preview_path.replace('.ply', '_with_class.ply')
+                    preview_with_class = preview_path.replace(
+                        '.ply', '_with_class.ply'
+                    )
                     if os.path.exists(preview_with_class):
                         os.replace(preview_with_class, preview_path)
-                    validate_ply_file(preview_path)
+                    if ENABLE_PLY_VALIDATION:
+                        validate_ply_file(preview_path)
                 except Exception as exc:
                     logging.warning(f"Failed to create preview PLY: {exc}")
             return redirect(

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -13,6 +13,7 @@ import sys
 import logging
 import shutil
 from typing import Any, Dict
+from settings import ENABLE_PLY_VALIDATION
 
 try:
     # Local helper to invoke Open3D in an external Python environment
@@ -71,7 +72,7 @@ def downsample_point_cloud(input_path, output_path, ratio=0.1, mode="ascii"):
             return False
 
 
-def validate_ply_file(ply_path, mode=None):
+def validate_ply_file(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
     """Validate PLY header and ensure correct point count and format.
 
     Parameters
@@ -81,7 +82,11 @@ def validate_ply_file(ply_path, mode=None):
     mode : str or None
         Desired format ("ascii" or "binary"). When ``None`` the existing
         file format is preserved.
+    validate : bool
+        Skip validation when ``False`` to improve performance.
     """
+    if not validate:
+        return True
     try:
         from plyfile import PlyData
 
@@ -142,7 +147,7 @@ def validate_ply_file(ply_path, mode=None):
         print(f"Failed to validate PLY file {ply_path}: {exc}")
         return False
  
-def add_class_field_to_ply(ply_path, mode=None):
+def add_class_field_to_ply(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
     """Duplicate green channel into 'class' and 'label' fields in a PLY file.
 
     Parameters
@@ -152,13 +157,16 @@ def add_class_field_to_ply(ply_path, mode=None):
     mode : str or None
         Output format, "ascii" or "binary". If ``None`` the input format is
         preserved.
+    validate : bool
+        Perform a full :func:`validate_ply_file` when True (default) but may
+        slow processing.
     """
     try:
         import numpy as np
         from plyfile import PlyData, PlyElement
 
         # Ensure PLY header is valid before processing
-        validate_ply_file(ply_path)
+        validate_ply_file(ply_path, validate=validate)
 
         output_ply_path = ply_path.replace('.ply', '_with_class.ply')
 
@@ -204,7 +212,7 @@ def add_class_field_to_ply(ply_path, mode=None):
 
         # Write the output without forcing text mode
         plydata_out.write(output_ply_path)
-        validate_ply_file(output_ply_path, mode)
+        validate_ply_file(output_ply_path, mode, validate)
         print(f"SUCCESS: Added class field to PLY and saved to {output_ply_path}")
 
     except Exception as exc:
@@ -440,6 +448,7 @@ def convert_to_point_cloud(
     pcd_mode="binary",
     ply_preview_pct=None,
     pcd_preview_pct=None,
+    validate=ENABLE_PLY_VALIDATION,
 ):
     import Metashape
 
@@ -486,7 +495,7 @@ def convert_to_point_cloud(
                     save_point_color=True,
                 )
                 if add_class_field:
-                    add_class_field_to_ply(output_path, mode="binary")
+                    add_class_field_to_ply(output_path, mode="binary", validate=validate)
                 ply_paths.append((output_path, "binary"))
                 print(f"ply Point cloud exported to {output_path}")
             if ply_mode in ("ascii", "both"):
@@ -501,7 +510,7 @@ def convert_to_point_cloud(
                     save_point_color=True,
                 )
                 if add_class_field:
-                    add_class_field_to_ply(output_path, mode="ascii")
+                    add_class_field_to_ply(output_path, mode="ascii", validate=validate)
                 ply_paths.append((output_path, "ascii"))
                 print(f"ply Point cloud exported to {output_path}")
 
@@ -572,7 +581,7 @@ def convert_to_point_cloud(
                 preview_path = path.replace('.ply', '_preview.ply')
                 if downsample_point_cloud(path, preview_path, ratio, pmode):
                     if add_class_field:
-                        add_class_field_to_ply(preview_path, mode=pmode)
+                        add_class_field_to_ply(preview_path, mode=pmode, validate=validate)
                         preview_with_class = preview_path.replace('.ply', '_with_class.ply')
                         if os.path.exists(preview_with_class):
                             os.replace(preview_with_class, preview_path)
@@ -656,6 +665,7 @@ if __name__ == "__main__":
     export_pcd = "--export_pcd" in sys.argv
     export_potree = "--export_potree" in sys.argv
     add_class_field = "--add_class_field" in sys.argv
+    validate = "--validate_ply" in sys.argv or ENABLE_PLY_VALIDATION  # integrity check
     ply_mode = sys.argv[sys.argv.index("--ply-mode") + 1] if "--ply-mode" in sys.argv else "binary"
     pcd_mode = sys.argv[sys.argv.index("--pcd-mode") + 1] if "--pcd-mode" in sys.argv else "binary"
     ply_preview_pct = float(sys.argv[sys.argv.index("--ply-preview-pct") + 1]) if "--ply-preview-pct" in sys.argv else None
@@ -710,6 +720,7 @@ if __name__ == "__main__":
             pcd_mode,
             ply_preview_pct,
             pcd_preview_pct,
+            validate,
         )
     
     if "--create_and_export_3d_model" in sys.argv:  
@@ -738,6 +749,7 @@ if __name__ == "__main__":
             pcd_mode,
             ply_preview_pct,
             pcd_preview_pct,
+            validate,
         )
         
     if "--video_full_pipeline" in sys.argv:  
@@ -782,4 +794,5 @@ if __name__ == "__main__":
             pcd_mode,
             ply_preview_pct,
             pcd_preview_pct,
+            validate,
         )

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,6 @@
+# Global settings for pipeline behavior.
+#
+# Enabling PLY validation performs additional integrity checks on point cloud
+# files but increases processing time. Disable to speed up pipelines once files
+# are trusted.
+ENABLE_PLY_VALIDATION = False

--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -16,6 +16,7 @@ import json
 from typing import Dict, List, Optional
 
 from metashape_script import add_class_field_to_ply
+from settings import ENABLE_PLY_VALIDATION
 import analysis
 
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png"}
@@ -48,6 +49,7 @@ def process_sign_pipeline(
     output_dir: str,
     analyses: Optional[List[str]] = None,
     add_class_field: bool = True,
+    validate: bool = ENABLE_PLY_VALIDATION,
 ) -> Dict[str, int]:
     """Run the sign detection pipeline.
 
@@ -59,6 +61,8 @@ def process_sign_pipeline(
             signs. If *add_class_field* is True and a PLY file is present, a new
             file with added ``class`` and ``label`` fields will be generated
             alongside it.
+        validate: When ``True`` run extra integrity checks on PLY files. Disable
+            for faster processing once files are trusted.
 
     Returns:
         A dictionary summarising the counts of detected sign classes.
@@ -84,7 +88,7 @@ def process_sign_pipeline(
                     ply_path = os.path.join(root, file)
                     if add_class_field:
                         try:
-                            add_class_field_to_ply(ply_path)
+                            add_class_field_to_ply(ply_path, validate=validate)
                             with_class = os.path.splitext(ply_path)[0] + "_with_class.ply"
                             if os.path.exists(with_class):
                                 ply_path = with_class


### PR DESCRIPTION
## Summary
- introduce `ENABLE_PLY_VALIDATION` settings flag
- make PLY validation optional in metashape and sign pipelines
- guard `/ply` route validation using the flag

## Testing
- `python -m py_compile app.py metashape_script.py sign_pipeline.py settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc33c80da88332ad4a823388396fc9