### PR TITLE
Avoid duplicate PLY writes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1812,12 +1812,7 @@ def ply(output_foldername, file_path):
             if not os.path.exists(preview_path):
                 try:
                     downsample_point_cloud(full_file_path, preview_path, ratio=0.1)
-                    add_class_field_to_ply(preview_path)
-                    preview_with_class = preview_path.replace(
-                        '.ply', '_with_class.ply'
-                    )
-                    if os.path.exists(preview_with_class):
-                        os.replace(preview_with_class, preview_path)
+                    add_class_field_to_ply(preview_path, overwrite=True)
                     if ENABLE_PLY_VALIDATION:
                         validate_ply_file(preview_path)
                 except Exception as exc:

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -147,7 +147,9 @@ def validate_ply_file(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
         print(f"Failed to validate PLY file {ply_path}: {exc}")
         return False
  
-def add_class_field_to_ply(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
+def add_class_field_to_ply(
+    ply_path, mode=None, validate=ENABLE_PLY_VALIDATION, overwrite=False
+):
     """Duplicate green channel into 'class' and 'label' fields in a PLY file.
 
     Parameters
@@ -160,6 +162,9 @@ def add_class_field_to_ply(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
     validate : bool
         Perform a full :func:`validate_ply_file` when True (default) but may
         slow processing.
+    overwrite : bool
+        When ``True`` rewrite ``ply_path`` in place instead of creating a new
+        file with ``_with_class`` suffix.
     """
     try:
         import numpy as np
@@ -167,8 +172,9 @@ def add_class_field_to_ply(ply_path, mode=None, validate=ENABLE_PLY_VALIDATION):
 
         # Ensure PLY header is valid before processing
         validate_ply_file(ply_path, validate=validate)
-
-        output_ply_path = ply_path.replace('.ply', '_with_class.ply')
+        output_ply_path = (
+            ply_path if overwrite else ply_path.replace('.ply', '_with_class.ply')
+        )
 
         plydata_in = PlyData.read(ply_path)
         if mode is None:
@@ -495,7 +501,9 @@ def convert_to_point_cloud(
                     save_point_color=True,
                 )
                 if add_class_field:
-                    add_class_field_to_ply(output_path, mode="binary", validate=validate)
+                    add_class_field_to_ply(
+                        output_path, mode="binary", validate=validate, overwrite=True
+                    )
                 ply_paths.append((output_path, "binary"))
                 print(f"ply Point cloud exported to {output_path}")
             if ply_mode in ("ascii", "both"):
@@ -510,7 +518,9 @@ def convert_to_point_cloud(
                     save_point_color=True,
                 )
                 if add_class_field:
-                    add_class_field_to_ply(output_path, mode="ascii", validate=validate)
+                    add_class_field_to_ply(
+                        output_path, mode="ascii", validate=validate, overwrite=True
+                    )
                 ply_paths.append((output_path, "ascii"))
                 print(f"ply Point cloud exported to {output_path}")
 
@@ -581,10 +591,9 @@ def convert_to_point_cloud(
                 preview_path = path.replace('.ply', '_preview.ply')
                 if downsample_point_cloud(path, preview_path, ratio, pmode):
                     if add_class_field:
-                        add_class_field_to_ply(preview_path, mode=pmode, validate=validate)
-                        preview_with_class = preview_path.replace('.ply', '_with_class.ply')
-                        if os.path.exists(preview_with_class):
-                            os.replace(preview_with_class, preview_path)
+                        add_class_field_to_ply(
+                            preview_path, mode=pmode, validate=validate, overwrite=True
+                        )
         if pcd_preview_pct:
             ratio = float(pcd_preview_pct) / 100.0
             for path, pmode in pcd_paths:

--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -80,24 +80,29 @@ def process_sign_pipeline(
                 indent=2,
             )
 
-        # Locate first PLY point cloud and optionally add classification fields
+        # Locate a PLY point cloud and optionally add classification fields
         ply_path = None
         for root, _, files in os.walk(output_dir):
+            # Prefer an already classified file if present
             for file in files:
-                if file.lower().endswith(".ply") and not file.lower().endswith("_with_class.ply"):
+                if file.lower().endswith("_with_class.ply"):
+                    ply_path = os.path.join(root, file)
+                    break
+            if ply_path:
+                break
+            for file in files:
+                if file.lower().endswith(".ply"):
                     ply_path = os.path.join(root, file)
                     if add_class_field:
                         try:
-                            add_class_field_to_ply(ply_path, validate=validate)
-                            with_class = os.path.splitext(ply_path)[0] + "_with_class.ply"
-                            if os.path.exists(with_class):
-                                ply_path = with_class
+                            add_class_field_to_ply(
+                                ply_path, validate=validate, overwrite=True
+                            )
                         except Exception:
                             pass
                     break
-            else:
-                continue
-            break
+            if ply_path:
+                break
 
         if analyses and ply_path:
             for name in analyses:


### PR DESCRIPTION
## Summary
- add optional `overwrite` flag to `add_class_field_to_ply` to rewrite files in place
- remove temporary `_with_class.ply` files and adjust callers to use in-place writes
- tweak sign pipeline to use in-place classification and prefer already classified point clouds

## Testing
- `python -m py_compile app.py metashape_script.py sign_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc3cb572148332b30114a2ffb80e27