### PR TITLE
fix: correct dat.gui import in PLY viewer

### DIFF
--- a/templates/ply.html
+++ b/templates/ply.html
@@ -23,7 +23,7 @@
         import * as THREE from 'three';
         import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
         import { PLYLoader } from 'three/addons/loaders/PLYLoader.js';
-        import GUI from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
+        import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
 
 
         let camera, scene, renderer, controls;


### PR DESCRIPTION
## Summary
- use named import for dat.gui to allow GUI panel to render in PLY viewer

## Testing
- `pytest`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d1d9df88332bc9303124035af36