### PR TITLE
Align sign bounding boxes with centered point clouds

### DIFF
--- a/templates/pcd_viewer.html
+++ b/templates/pcd_viewer.html
@@ -405,6 +405,7 @@
         let debugMode = false;
         let urlDebugMode = false;
         let isUrlMode = false;
+        let centeringOffset = new THREE.Vector3();
 
         // Check URL for file parameter and load if present
         function checkUrlForFile() {
@@ -571,7 +572,9 @@
                     const geometry = points.geometry;
                     geometry.rotateX(0);
                     geometry.rotateY(0);
-                    geometry.center();
+                    geometry.computeBoundingBox();
+                    centeringOffset = geometry.boundingBox.getCenter(new THREE.Vector3());
+                    geometry.translate(-centeringOffset.x, -centeringOffset.y, -centeringOffset.z);
                     
                     processPointCloud(points);
                     resolve(points);
@@ -602,7 +605,9 @@
                     // Apply transformations
                     geometry.rotateX(0);
                     geometry.rotateY(0);
-                    geometry.center();
+                    geometry.computeBoundingBox();
+                    centeringOffset = geometry.boundingBox.getCenter(new THREE.Vector3());
+                    geometry.translate(-centeringOffset.x, -centeringOffset.y, -centeringOffset.z);
                     
                     const material = new THREE.PointsMaterial({ size: 0.02, vertexColors: true, sizeAttenuation: true });
                     const points = new THREE.Points(geometry, material);

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -466,6 +466,7 @@
         let measurementObjects = [];
         let signBboxGroup;
         let signBboxesLoaded = false;
+        let centeringOffset = new THREE.Vector3();
         const SERVER_OUTPUT_FOLDER = {{ output_foldername|tojson if output_foldername is defined else 'null' }};
         const SERVER_FILE_PATH = {{ file_path|tojson if file_path is defined else 'null' }};
         let currentOutputFolder = SERVER_OUTPUT_FOLDER;
@@ -602,7 +603,9 @@
                     const geometry = points.geometry;
                     geometry.rotateX(0);
                     geometry.rotateY(0);
-                    geometry.center();
+                    geometry.computeBoundingBox();
+                    centeringOffset = geometry.boundingBox.getCenter(new THREE.Vector3());
+                    geometry.translate(-centeringOffset.x, -centeringOffset.y, -centeringOffset.z);
 
                     processPointCloud(points);
                     resolve(points);
@@ -646,7 +649,9 @@
                     // Apply transformations
                     geometry.rotateX(0);
                     geometry.rotateY(0);
-                    geometry.center();
+                    geometry.computeBoundingBox();
+                    centeringOffset = geometry.boundingBox.getCenter(new THREE.Vector3());
+                    geometry.translate(-centeringOffset.x, -centeringOffset.y, -centeringOffset.z);
 
                     const material = new THREE.PointsMaterial({ size: 0.01, vertexColors: true });
                     const points = new THREE.Points(geometry, material);
@@ -1190,8 +1195,8 @@
                 }
                 const boxes = await response.json();
                 boxes.forEach(box => {
-                    const min = new THREE.Vector3(...box.min);
-                    const max = new THREE.Vector3(...box.max);
+                    const min = new THREE.Vector3(...box.min).sub(centeringOffset);
+                    const max = new THREE.Vector3(...box.max).sub(centeringOffset);
                     const dx = max.x - min.x;
                     const dy = max.y - min.y;
                     const dz = max.z - min.z;


### PR DESCRIPTION
## Summary
- Compute and store point cloud centering offset when loading PCD/PLY files
- Offset sign bounding box coordinates by the point cloud's centering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc521101308332b6e80b03d5f571db