### PR TITLE
Add client-side model rotation controls to viewer

### DIFF
--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -399,6 +399,15 @@
                     <span id="pointSizeValue">0.02</span>
                 </div>
                 <div style="margin-top: 10px;">
+                    <label>چرخش مدل (درجه):</label>
+                    <div style="display: flex; align-items: center; gap: 4px; margin-top: 5px;">
+                        X:<input type="number" id="rotX" value="0" style="width: 60px;">
+                        Y:<input type="number" id="rotY" value="0" style="width: 60px;">
+                        Z:<input type="number" id="rotZ" value="0" style="width: 60px;">
+                        <button class="button" id="applyRotationBtn">اعمال</button>
+                    </div>
+                </div>
+                <div style="margin-top: 10px;">
                     <button class="button" id="resetCameraBtn">بازنشانی دوربین</button>
                     <button class="button" id="toggleDebugBtn">نمایش اطلاعات دیباگ</button>
                     <button class="button" id="toggleUrlDebugBtn">نمایش دیباگ URL</button>
@@ -764,6 +773,24 @@
             document.getElementById('measureDistanceBtn').addEventListener('click', startDistanceMeasurement);
             document.getElementById('measureAreaBtn').addEventListener('click', startAreaMeasurement);
             document.getElementById('clearMeasureBtn').addEventListener('click', clearMeasurement);
+            document.getElementById('applyRotationBtn').addEventListener('click', () => {
+                const rad = THREE.MathUtils.degToRad;
+                const x = rad(parseFloat(document.getElementById('rotX').value) || 0);
+                const y = rad(parseFloat(document.getElementById('rotY').value) || 0);
+                const z = rad(parseFloat(document.getElementById('rotZ').value) || 0);
+                if (pointCloud) {
+                    pointCloud.rotation.set(x, y, z);
+                }
+            });
+
+            window.addEventListener('keydown', (e) => {
+                const step = THREE.MathUtils.degToRad(5);
+                if (!pointCloud) return;
+                if (e.key === 'ArrowLeft')  pointCloud.rotation.y -= step;
+                if (e.key === 'ArrowRight') pointCloud.rotation.y += step;
+                if (e.key === 'ArrowUp')    pointCloud.rotation.x -= step;
+                if (e.key === 'ArrowDown')  pointCloud.rotation.x += step;
+            });
 
             const bboxToggle = document.getElementById('showSignBBoxes');
             if (bboxToggle) {


### PR DESCRIPTION
## Summary
- add numeric rotation inputs and apply button in viewer controls
- allow rotating point clouds via arrow keys and degree inputs on the client

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc7a8e4ac08332ade701b6e4c9b6a9