### PR TITLE
Show classification status in process list

### DIFF
--- a/templates/process_list.html
+++ b/templates/process_list.html
@@ -517,7 +517,7 @@
                     <th>کاربر</th>
                     <th>تعداد فریم/تصویر</th>
                     <th>زمان شروع</th>
-                    <th>زمان پایان</th>
+                    <th>کلاس‌بندی شده؟</th>
                     <th>مدت‌زمان (ثانیه)</th>
                     <th>وضعیت</th>
                     <th>عملیات</th>
@@ -539,7 +539,9 @@
                         <div class="time-display">{{ p.start_time }}</div>
                     </td>
                     <td class="table-cell">
-                        <div class="time-display">{{ p.end_time or '-' }}</div>
+                        <span class="status-badge {{ 'status-completed' if p.has_classification else 'status-failed' }}">
+                            {{ 'بله' if p.has_classification else 'خیر' }}
+                        </span>
                     </td>
                     <td class="table-cell">
                         {% if p.duration %}


### PR DESCRIPTION
## Summary
- Replace end date column with a classification status column on the process list page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc898a86ec833285f47172fc92a914