### PR TITLE
fix: correct point cloud coordinate handling

### DIFF
--- a/o3d_worker.py
+++ b/o3d_worker.py
@@ -2,13 +2,16 @@ import json
 import sys
 import open3d as o3d
 import numpy as np
+from settings import PLY_ROUND_COORDS, PLY_ROUND_DECIMALS
 
 
 def downsample(in_path: str, out_path: str, ratio: float):
     pcd = o3d.io.read_point_cloud(in_path)
     sampled = pcd.random_down_sample(ratio)
     points = np.asarray(sampled.points)
-    sampled.points = o3d.utility.Vector3dVector(np.round(points, 2))
+    if PLY_ROUND_COORDS:
+        points = np.round(points, PLY_ROUND_DECIMALS)
+    sampled.points = o3d.utility.Vector3dVector(points)
     o3d.io.write_point_cloud(out_path, sampled, write_ascii=True)
     return {
         "ok": True,

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -966,12 +966,21 @@
                     classDistribution[classId]++;
                 }
 
+                const originalX = positions[i] + centeringOffset.x;
+                const originalY = positions[i + 1] + centeringOffset.y;
+                const originalZ = positions[i + 2] + centeringOffset.z;
+
                 pointsData.push({
                     index: pointIndex,
                     position: {
                         x: positions[i],
                         y: positions[i + 1],
                         z: positions[i + 2]
+                    },
+                    originalPosition: {
+                        x: originalX,
+                        y: originalY,
+                        z: originalZ
                     },
                     color: { // همیشه رنگ را از colors اصلی بخوان
                         r: colors[i],
@@ -1386,6 +1395,13 @@
             const pointInfo = document.getElementById('point-info');
             const pointDetails = document.getElementById('point-details');
 
+            pointCloud.updateMatrixWorld();
+            const worldPos = pointCloud.localToWorld(new THREE.Vector3(
+                point.originalPosition.x,
+                point.originalPosition.y,
+                point.originalPosition.z
+            ));
+
             if (HAS_CLASSIFICATION) {
                 const className = CLASS_LABELS_FA[point.classId] || `کلاس ${point.classId}`;
                 pointDetails.innerHTML = `
@@ -1399,15 +1415,15 @@
                     </div>
                     <div class="point-info-item">
                         <span>موقعیت X:</span>
-                        <span class="point-info-label">${point.position.x.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.x.toFixed(3)}</span>
                     </div>
-                    <div class="point-info-item">
+                        <div class="point-info-item">
                         <span>موقعیت Y:</span>
-                        <span class="point-info-label">${point.position.y.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.y.toFixed(3)}</span>
                     </div>
                     <div class="point-info-item">
                         <span>موقعیت Z:</span>
-                        <span class="point-info-label">${point.position.z.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.z.toFixed(3)}</span>
                     </div>
                     <div class="point-info-item">
                         <span>رنگ RGB:</span>
@@ -1434,15 +1450,15 @@
                     </div>
                     <div class="point-info-item">
                         <span>موقعیت X:</span>
-                        <span class="point-info-label">${point.position.x.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.x.toFixed(3)}</span>
                     </div>
                     <div class="point-info-item">
                         <span>موقعیت Y:</span>
-                        <span class="point-info-label">${point.position.y.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.y.toFixed(3)}</span>
                     </div>
                     <div class="point-info-item">
                         <span>موقعیت Z:</span>
-                        <span class="point-info-label">${point.position.z.toFixed(3)}</span>
+                        <span class="point-info-label">${worldPos.z.toFixed(3)}</span>
                     </div>
                     <div class="point-info-item">
                         <span>رنگ RGB:</span>


### PR DESCRIPTION
## Summary
- obey `PLY_ROUND_COORDS`/`PLY_ROUND_DECIMALS` when downsampling point clouds
- retain original point positions and display coordinates in world space in viewer

## Testing
- `python -m py_compile o3d_worker.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc830be040833282834dd5a1cdb59c