### PR TITLE
Fix PLY class field write on Windows

### DIFF
--- a/metashape_script.py
+++ b/metashape_script.py
@@ -227,7 +227,8 @@ def add_class_field_to_ply(
 
         # Write the output without forcing text mode
         output_ply_path = output_ply_path.resolve()
-        plydata_out.write(str(output_ply_path))
+        with open(output_ply_path, "wb") as fh:
+            plydata_out.write(fh)
         validate_ply_file(str(output_ply_path), mode, validate)
         print(f"SUCCESS: Added class field to PLY and saved to {output_ply_path}")
 


### PR DESCRIPTION
## Summary
- ensure PLY class-field injection opens file handle explicitly before writing to avoid Windows path issues

## Testing
- `python -m py_compile metashape_script.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc9141ef208332a2079a7ac200cd8c