### PR TITLE
Wrap rotation controls to show apply button

### DIFF
--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -43,6 +43,7 @@
             color: #333;
             padding: 20px;
             overflow-y: auto;
+            overflow-x: hidden;
             border-left: 2px solid #ddd;
         }
 
@@ -416,7 +417,7 @@
                 </div>
                 <div style="margin-top: 10px;">
                     <label>چرخش مدل (درجه):</label>
-                    <div style="display: flex; align-items: center; gap: 4px; margin-top: 5px;">
+                    <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 4px; margin-top: 5px;">
                         X:<input type="number" id="rotX" value="0" class="rot-input">
                         Y:<input type="number" id="rotY" value="0" class="rot-input">
                         Z:<input type="number" id="rotZ" value="0" class="rot-input">


### PR DESCRIPTION
## Summary
- wrap rotation controls so the apply button doesn't require scrolling
- hide horizontal overflow on the control panel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc992371348332b17eacb3826d6d26