### PR TITLE
Fix PLY class field output path reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -1812,7 +1812,7 @@ def ply(output_foldername, file_path):
             if not os.path.exists(preview_path):
                 try:
                     downsample_point_cloud(full_file_path, preview_path, ratio=0.1)
-                    add_class_field_to_ply(preview_path, overwrite=False)
+                    add_class_field_to_ply(preview_path)
                     if ENABLE_PLY_VALIDATION:
                         validate_ply_file(preview_path)
                 except Exception as exc:

--- a/metashape_script.py
+++ b/metashape_script.py
@@ -228,19 +228,16 @@ def add_class_field_to_ply(
         # Write the output without forcing text mode. On Windows the long-path
         # prefix (``\\\\?\\``) avoids ``OSError: [Errno 22]`` when paths contain
         # UUIDs or otherwise exceed the traditional 260 character limit.
-        output_ply_str = str(output_ply_path)
+        output_ply_str = os.fspath(output_ply_path)
         if os.name == "nt":
-            output_ply_str = output_ply_str.replace("/", "\\")  # مطمئن شوید اسلش درست باشد
-        if not output_ply_str.startswith(r"\\?\\"):
-            output_ply_str = r"\\?\\" + output_ply_str
-        # output_ply_str = os.fspath(output_ply_path)
-        # if os.name == "nt" and not output_ply_str.startswith("\\\\?\\"):
-        #     output_ply_str = "\\\\?\\" + output_ply_str
-        # with open(output_ply_str, "wb") as fh:
-        #     plydata_out.write(fh)
+            output_ply_str = output_ply_str.replace("/", "\\")
+            if not output_ply_str.startswith("\\\\?\\"):
+                output_ply_str = "\\\\?\\" + output_ply_str
+        with open(output_ply_str, "wb") as fh:
+            plydata_out.write(fh)
         validate_ply_file(output_ply_str, mode, validate)
         print(
-            f"SUCCESS: Added class field to PLY and saved to {output_ply_str}"
+            f"SUCCESS: Added class field to PLY and saved to {output_ply_path.resolve()}"
         )
 
     except Exception as exc:
@@ -560,7 +557,7 @@ def convert_to_point_cloud(
                 )
                 if add_class_field:
                     add_class_field_to_ply(
-                        output_path, mode="binary", validate=validate, overwrite=False
+                        output_path, mode="binary", validate=validate
                     )
                 ply_paths.append((output_path, "binary"))
                 print(f"ply Point cloud exported to {output_path}")
@@ -577,7 +574,7 @@ def convert_to_point_cloud(
                 )
                 if add_class_field:
                     add_class_field_to_ply(
-                        output_path, mode="ascii", validate=validate, overwrite=False
+                        output_path, mode="ascii", validate=validate
                     )
                 ply_paths.append((output_path, "ascii"))
                 print(f"ply Point cloud exported to {output_path}")
@@ -650,7 +647,7 @@ def convert_to_point_cloud(
                 if downsample_point_cloud(path, preview_path, ratio, pmode):
                     if add_class_field:
                         add_class_field_to_ply(
-                            preview_path, mode=pmode, validate=validate, overwrite=False
+                            preview_path, mode=pmode, validate=validate
                         )
         if pcd_preview_pct:
             ratio = float(pcd_preview_pct) / 100.0

--- a/sign_pipeline.py
+++ b/sign_pipeline.py
@@ -96,7 +96,7 @@ def process_sign_pipeline(
                     if add_class_field:
                         try:
                             add_class_field_to_ply(
-                                ply_path, validate=validate, overwrite=False
+                                ply_path, validate=validate
                             )
                         except Exception:
                             pass


### PR DESCRIPTION
## Summary
- Ensure `add_class_field_to_ply` writes PLY files and reports the resolved output path
- Default to non-overwrite behavior and simplify callers

## Testing
- `python -m py_compile metashape_script.py sign_pipeline.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf00d7108332a68f48a82d166253