### PR TITLE
Ensure Windows PLY output path is absolute

### DIFF
--- a/metashape_script.py
+++ b/metashape_script.py
@@ -181,6 +181,9 @@ def add_class_field_to_ply(
         output_ply_path = (
             ply_path if overwrite else ply_path.with_name(ply_path.stem + '_with_class.ply')
         )
+        # Convert to absolute path so the Windows long-path prefix works with
+        # relative ``ply_path`` values.
+        output_ply_path = output_ply_path.resolve()
 
         plydata_in = PlyData.read(str(ply_path))
         if mode is None:
@@ -228,6 +231,7 @@ def add_class_field_to_ply(
         # Write the output without forcing text mode. On Windows the long-path
         # prefix (``\\\\?\\``) avoids ``OSError: [Errno 22]`` when paths contain
         # UUIDs or otherwise exceed the traditional 260 character limit.
+        output_ply_path.parent.mkdir(parents=True, exist_ok=True)
         output_ply_str = os.fspath(output_ply_path)
         if os.name == "nt":
             output_ply_str = output_ply_str.replace("/", "\\")


### PR DESCRIPTION
## Summary
- Resolve output PLY path to absolute before applying Windows long-path prefix
- Create parent directory and handle long-path prefix correctly when writing PLY files

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb7e33a1c8332aaddbe2e5a6efec0